### PR TITLE
Fix the smtp issues

### DIFF
--- a/services/adminProfileService.ts
+++ b/services/adminProfileService.ts
@@ -59,7 +59,7 @@ export class AdminProfileService {
   }
 
   /**
-   * Upload admin profile picture
+   * Upload admin profile pictures
    */
   async uploadProfilePicture(file: File): Promise<FileUploadResponse> {
     try {


### PR DESCRIPTION
chore(email): authenticate ZeptoMail via GoDaddy DNS

- Added SPF record (`include:zeptomail.in`) to authorize ZeptoMail servers.
- Verified existing DMARC and DKIM configurations in GoDaddy.
- Fixed the issue where transactional emails were landing in the spam folder.