### PR TITLE
Updated filter button all

### DIFF
--- a/app/dashboard/admin/assessments/page.tsx
+++ b/app/dashboard/admin/assessments/page.tsx
@@ -1,6 +1,6 @@
-"use client"
+'use client'
 
-import { useState, useEffect } from 'react'
+import { useMemo, useState, useEffect } from 'react'
 import { AssessmentList } from '@/components/admin/AssessmentList'
 import { AssessmentDetailsModal } from '@/components/admin/assessments/AssessmentDetailsModal'
 import { apiClient } from '@/lib/api'
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/button'
 import { Plus } from 'lucide-react'
 import Link from 'next/link'
 import { AdminDashboardLayout } from '@/components/dashboard/AdminDashboardLayout'
-
+import { MobileFilterBottomSheet } from '@/components/ui/MobileFilterBottomSheet'
 
 interface Assessment {
   id: string
@@ -25,6 +25,9 @@ interface Assessment {
   instructions?: string
 }
 
+const selectClass =
+  'w-full px-3 py-2.5 bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 outline-none text-sm text-gray-900 dark:text-white'
+
 export default function AssessmentsPage() {
   const [assessments, setAssessments] = useState<Assessment[]>([])
   const [isLoading, setIsLoading] = useState(true)
@@ -32,17 +35,26 @@ export default function AssessmentsPage() {
   const [filters, setFilters] = useState({
     status: 'all',
     mode: 'all',
-    search: ''
+    search: '',
   })
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [draftStatus, setDraftStatus] = useState('all')
+  const [draftMode, setDraftMode] = useState('all')
 
   const [selectedAssessment, setSelectedAssessment] = useState<Assessment | null>(null)
   const [isViewModalOpen, setIsViewModalOpen] = useState(false)
 
-  // Fetch assessments
+  const activeFilterCount = useMemo(() => {
+    let n = 0
+    if (filters.status !== 'all') n += 1
+    if (filters.mode !== 'all') n += 1
+    return n
+  }, [filters.status, filters.mode])
+
   const fetchAssessments = async () => {
     try {
       setIsLoading(true)
-      const data = await apiClient.getAdminAssessments();
+      const data = await apiClient.getAdminAssessments()
       setAssessments(data || [])
     } catch (err: any) {
       console.error('Failed to fetch assessments:', err)
@@ -56,52 +68,59 @@ export default function AssessmentsPage() {
     fetchAssessments()
   }, [])
 
-  // Actions
   const handleEdit = (id: string) => {
-    window.location.href = `/dashboard/admin/assessments/${id}/edit`;
-  };
+    window.location.href = `/dashboard/admin/assessments/${id}/edit`
+  }
 
   const handleView = (id: string) => {
-    const assessment = assessments.find(a => a.id === id)
+    const assessment = assessments.find((a) => a.id === id)
     if (assessment) {
       setSelectedAssessment(assessment)
       setIsViewModalOpen(true)
     }
-  };
+  }
 
   const handleDelete = async (id: string) => {
     try {
-      await apiClient.delete(`/admin/assessments/${id}`);
-      fetchAssessments(); // Refresh
+      await apiClient.delete(`/admin/assessments/${id}`)
+      fetchAssessments()
     } catch (err) {
-      alert("Failed to delete assessment");
+      alert('Failed to delete assessment')
     }
-  };
+  }
 
-  // Filter assessments
-  const filteredAssessments = assessments.filter(assessment => {
+  const filteredAssessments = assessments.filter((assessment) => {
     if (filters.status !== 'all' && assessment.status !== filters.status) return false
     if (filters.mode !== 'all' && assessment.mode !== filters.mode) return false
-    if (filters.search && !assessment.assessment_name.toLowerCase().includes(filters.search.toLowerCase())) return false
+    if (
+      filters.search &&
+      !assessment.assessment_name.toLowerCase().includes(filters.search.toLowerCase())
+    )
+      return false
     return true
   })
 
+  const openSheet = () => {
+    setDraftStatus(filters.status)
+    setDraftMode(filters.mode)
+    setSheetOpen(true)
+  }
+
   return (
     <AdminDashboardLayout>
-      <div className="space-y-8 min-h-screen bg-transparent">
-        {/* Header Section */}
-        <div className="bg-gradient-to-r from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20 rounded-2xl p-6 border border-purple-200 dark:border-purple-700">
-          <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 lg:gap-6">
-            <div className="flex-1 min-w-0">
-              <h1 className="text-2xl md:text-3xl font-bold text-gray-900 dark:text-white mb-2">
+      <div className="min-h-screen space-y-8 bg-transparent">
+        <div className="rounded-2xl border border-purple-200 bg-gradient-to-r from-purple-50 to-blue-50 p-6 dark:border-purple-700 dark:from-purple-900/20 dark:to-blue-900/20">
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between lg:gap-6">
+            <div className="min-w-0 flex-1">
+              <h1 className="mb-2 text-2xl font-bold text-gray-900 dark:text-white md:text-3xl">
                 Assessments & Exams 📝
               </h1>
-              <p className="text-gray-600 dark:text-gray-300 text-lg mb-3">
+              <p className="mb-3 text-lg text-gray-600 dark:text-gray-300">
                 Manage hiring tests, university exams, and practice modules.
               </p>
             </div>
             <Link href="/dashboard/admin/assessments/create">
-              <Button className="bg-purple-600 hover:bg-purple-700 text-white shadow-md hover:shadow-lg transition-all flex items-center gap-2 h-11 px-6 rounded-lg w-full sm:w-auto justify-center">
+              <Button className="flex h-11 w-full items-center justify-center gap-2 rounded-lg bg-purple-600 px-6 text-white shadow-md transition-all hover:bg-purple-700 hover:shadow-lg sm:w-auto">
                 <Plus size={20} strokeWidth={2.5} />
                 <span className="font-semibold">Create Assessment</span>
               </Button>
@@ -109,39 +128,99 @@ export default function AssessmentsPage() {
           </div>
         </div>
 
-        {/* Filters Section */}
-        <div className="grid grid-cols-1 md:grid-cols-12 gap-4 bg-white dark:bg-gray-800 p-4 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700">
-          <div className="md:col-span-6 lg:col-span-8">
-            <div className="relative">
+        <div className="rounded-xl border border-gray-100 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+          <div className="flex gap-2">
+            <div className="relative min-w-0 flex-1">
               <input
                 type="text"
                 placeholder="Search assessments..."
                 value={filters.search}
                 onChange={(e) => setFilters({ ...filters, search: e.target.value })}
-                className="w-full pl-10 pr-4 py-2.5 bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 outline-none transition-all text-gray-900 dark:text-white placeholder:text-gray-400 dark:placeholder:text-gray-400"
+                className="w-full rounded-lg border border-gray-200 bg-gray-50 py-2.5 pl-10 pr-4 text-gray-900 outline-none transition-all placeholder:text-gray-400 focus:border-blue-500 focus:ring-2 focus:ring-blue-500/20 dark:border-gray-700 dark:bg-gray-700/40 dark:text-white dark:placeholder:text-gray-400"
               />
-              <svg className="absolute left-3.5 top-3 h-5 w-5 text-gray-400 dark:text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              <svg
+                className="absolute left-3.5 top-3 h-5 w-5 text-gray-400 dark:text-gray-500"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+                />
               </svg>
             </div>
+            <MobileFilterBottomSheet
+              open={sheetOpen}
+              onOpenChange={(open) => {
+                if (open) openSheet()
+                else setSheetOpen(false)
+              }}
+              activeCount={activeFilterCount}
+              onApply={() =>
+                setFilters((prev) => ({ ...prev, status: draftStatus, mode: draftMode }))
+              }
+              onClear={() => {
+                setDraftStatus('all')
+                setDraftMode('all')
+                setFilters((prev) => ({ ...prev, status: 'all', mode: 'all' }))
+              }}
+              clearLabel="Reset"
+              applyLabel="Apply"
+            >
+              <div className="space-y-4">
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Status
+                  </label>
+                  <select
+                    value={draftStatus}
+                    onChange={(e) => setDraftStatus(e.target.value)}
+                    className={selectClass}
+                  >
+                    <option value="all">All Status</option>
+                    <option value="DRAFT">Draft</option>
+                    <option value="ACTIVE">Active</option>
+                    <option value="COMPLETED">Completed</option>
+                  </select>
+                </div>
+                <div className="space-y-1.5">
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    Mode
+                  </label>
+                  <select
+                    value={draftMode}
+                    onChange={(e) => setDraftMode(e.target.value)}
+                    className={selectClass}
+                  >
+                    <option value="all">All Modes</option>
+                    <option value="HIRING">Hiring</option>
+                    <option value="UNIVERSITY">University</option>
+                    <option value="CORPORATE">Corporate</option>
+                  </select>
+                </div>
+              </div>
+            </MobileFilterBottomSheet>
           </div>
-          <div className="md:col-span-3 lg:col-span-2">
+
+          {/* Desktop filters */}
+          <div className="mt-3 hidden gap-3 md:grid md:grid-cols-2">
             <select
               value={filters.status}
               onChange={(e) => setFilters({ ...filters, status: e.target.value })}
-              className="w-full px-3 py-2.5 bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 outline-none text-sm text-gray-900 dark:text-white"
+              className={selectClass}
             >
               <option value="all">All Status</option>
               <option value="DRAFT">Draft</option>
               <option value="ACTIVE">Active</option>
               <option value="COMPLETED">Completed</option>
             </select>
-          </div>
-          <div className="md:col-span-3 lg:col-span-2">
             <select
               value={filters.mode}
               onChange={(e) => setFilters({ ...filters, mode: e.target.value })}
-              className="w-full px-3 py-2.5 bg-gray-50 dark:bg-gray-700/40 border border-gray-200 dark:border-gray-700 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 outline-none text-sm text-gray-900 dark:text-white"
+              className={selectClass}
             >
               <option value="all">All Modes</option>
               <option value="HIRING">Hiring</option>
@@ -151,17 +230,20 @@ export default function AssessmentsPage() {
           </div>
         </div>
 
-        {/* Error State */}
         {error && !isLoading && (
-          <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg p-4 flex items-center gap-3 text-red-700 dark:text-red-300">
+          <div className="flex items-center gap-3 rounded-lg border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
             <svg className="h-5 w-5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
             </svg>
             {error}
           </div>
         )}
 
-        {/* Content */}
         <AssessmentList
           assessments={filteredAssessments}
           loading={isLoading}
@@ -175,8 +257,6 @@ export default function AssessmentsPage() {
           onClose={() => setIsViewModalOpen(false)}
           assessment={selectedAssessment}
         />
-
-
       </div>
     </AdminDashboardLayout>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -228,7 +228,8 @@ html, body {
 /* Ensure bottom navbar is always visible */
 @media (max-width: 1023px) {
   body {
-    padding-bottom: calc(4rem + env(safe-area-inset-bottom));
+    /* Clear fixed mobile bottom nav (min 44px targets) + safe area */
+    padding-bottom: calc(4.75rem + env(safe-area-inset-bottom));
   }
 }
 

--- a/components/dashboard/AdminSidebar.tsx
+++ b/components/dashboard/AdminSidebar.tsx
@@ -35,6 +35,7 @@ import Image from 'next/image'
 import { useLoading } from '@/contexts/LoadingContext'
 import { adminProfileService } from '@/services/adminProfileService'
 import { navItemIsActive } from '@/lib/adminNav'
+import { MobileBottomNav, MobileBottomNavAction } from '@/components/ui/MobileBottomNav'
 
 interface NavItem {
     label: string
@@ -198,6 +199,7 @@ export function AdminSidebar({ className = '' }: AdminSidebarProps) {
     const [imageError, setImageError] = useState(false)
     const pathname = usePathname()
     const { user, logout } = useAuth()
+    const { startLoading } = useLoading()
     const desktopNavRef = useRef<HTMLDivElement>(null)
 
     // Fetch profile data when component mounts
@@ -374,40 +376,24 @@ export function AdminSidebar({ className = '' }: AdminSidebarProps) {
             </div>
 
             {/* Mobile Bottom Navigation */}
-            <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 z-50 shadow-lg pb-safe" style={{ touchAction: 'none' }}>
-                <div className="flex justify-around items-center py-1.5 px-1 w-full">
-                    {navItems.slice(0, 5).map((item) => {
-                        const isActive = navItemIsActive(pathname, item.href)
-                        const { startLoading } = useLoading()
-
-                        const handleClick = () => {
-                            if (!isActive) {
-                                startLoading()
-                            }
-                        }
-
-                        return (
-                            <Link
-                                key={item.href}
-                                href={item.href}
-                                onClick={handleClick}
-                                className={`flex items-center justify-center p-2 rounded-lg transition-all duration-200 w-full max-w-[20%] ${isActive
-                                    ? 'text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20'
-                                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700'
-                                    }`}
-                            >
-                                <item.icon className="w-5 h-5 sm:w-6 sm:h-6" />
-                            </Link>
-                        )
-                    })}
-                    <button
+            <MobileBottomNav
+                aria-label="Admin mobile navigation"
+                items={navItems.slice(0, 5).map((item) => ({
+                    href: item.href,
+                    label: item.label,
+                    shortLabel: item.label.split(' ')[0],
+                    icon: item.icon,
+                    active: navItemIsActive(pathname, item.href),
+                    onNavigate: startLoading,
+                }))}
+                trailing={
+                    <MobileBottomNavAction
+                        label="More"
+                        icon={Menu}
                         onClick={toggleMobileMenu}
-                        className="flex items-center justify-center p-2 rounded-lg text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700 transition-all duration-200 w-full max-w-[20%]"
-                    >
-                        <Menu className="w-5 h-5 sm:w-6 sm:h-6" />
-                    </button>
-                </div>
-            </div>
+                    />
+                }
+            />
 
             {/* Mobile Menu Overlay */}
             <AnimatePresence>

--- a/components/dashboard/CorporateSidebar.tsx
+++ b/components/dashboard/CorporateSidebar.tsx
@@ -315,20 +315,20 @@ export function CorporateSidebar({ className = '' }: CorporateSidebarProps) {
                                                 if (!active) startLoading()
                                             }}
                                             className={cn(
-                                                'relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 py-1 rounded-xl transition-colors',
+                                                'relative flex min-h-[44px] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl py-1 transition-colors',
                                                 active ? 'text-blue-400' : 'text-gray-400'
                                             )}
                                         >
                                             <span
                                                 className={cn(
-                                                    'flex items-center justify-center w-9 h-9 rounded-xl transition-all',
+                                                    'flex h-9 w-9 items-center justify-center rounded-xl transition-all',
                                                     active &&
                                                         'bg-gradient-to-br from-blue-500 to-violet-600 text-white shadow-md shadow-blue-500/35'
                                                 )}
                                             >
-                                                <item.icon className="w-[18px] h-[18px]" />
+                                                <item.icon className="h-[18px] w-[18px]" />
                                             </span>
-                                            <span className="text-[9px] font-medium truncate max-w-full leading-tight">
+                                            <span className="max-w-full truncate text-[10px] font-medium leading-tight">
                                                 {item.label}
                                             </span>
                                             {active && (
@@ -340,12 +340,12 @@ export function CorporateSidebar({ className = '' }: CorporateSidebarProps) {
                                 <button
                                     type="button"
                                     onClick={() => setIsMobileMenuOpen(true)}
-                                    className="relative flex flex-col items-center justify-center gap-0.5 flex-1 min-w-0 py-1 rounded-xl text-gray-400"
+                                    className="relative flex min-h-[44px] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl py-1 text-gray-400"
                                 >
-                                    <span className="flex items-center justify-center w-9 h-9 rounded-xl">
-                                        <MoreHorizontal className="w-[18px] h-[18px]" />
+                                    <span className="flex h-9 w-9 items-center justify-center rounded-xl">
+                                        <MoreHorizontal className="h-[18px] w-[18px]" />
                                     </span>
-                                    <span className="text-[9px] font-medium leading-tight">More</span>
+                                    <span className="text-[10px] font-medium leading-tight">More</span>
                                 </button>
                             </div>
                         </div>

--- a/components/dashboard/DashboardStats.tsx
+++ b/components/dashboard/DashboardStats.tsx
@@ -59,6 +59,7 @@ export function DashboardStats({ className = '' }: DashboardStatsProps) {
       value: stats.totalJobs,
       icon: Briefcase,
       subtitle: 'Open opportunities',
+      tooltip: 'Total open job opportunities currently available to you',
       colorClass: 'text-blue-500',
       iconBgClass: 'bg-blue-500/15',
     },
@@ -67,6 +68,7 @@ export function DashboardStats({ className = '' }: DashboardStatsProps) {
       value: stats.appliedJobs,
       icon: FileText,
       subtitle: 'Submitted',
+      tooltip: 'Number of job applications you have submitted',
       colorClass: 'text-emerald-500',
       iconBgClass: 'bg-emerald-500/15',
     },
@@ -75,6 +77,7 @@ export function DashboardStats({ className = '' }: DashboardStatsProps) {
       value: stats.selected,
       icon: Trophy,
       subtitle: stats.selected > 0 ? 'Congratulations!' : 'Keep going',
+      tooltip: 'Applications where you were selected by the employer',
       colorClass: 'text-violet-500',
       iconBgClass: 'bg-violet-500/15',
     },
@@ -83,6 +86,7 @@ export function DashboardStats({ className = '' }: DashboardStatsProps) {
       value: stats.rejected,
       icon: XCircle,
       subtitle: 'Keep Trying!',
+      tooltip: 'Applications that were not selected — keep applying',
       colorClass: 'text-red-500',
       iconBgClass: 'bg-red-500/15',
     },
@@ -126,6 +130,7 @@ export function DashboardStats({ className = '' }: DashboardStatsProps) {
           value={stat.value}
           icon={stat.icon}
           subtitle={stat.subtitle}
+          tooltip={stat.tooltip}
           colorClass={stat.colorClass}
           iconBgClass={stat.iconBgClass}
           index={index}

--- a/components/dashboard/JobCard.tsx
+++ b/components/dashboard/JobCard.tsx
@@ -6,6 +6,8 @@ import { formatSalaryRange } from '@/lib/currency'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { CompanyLogo } from '@/components/jobs/CompanyLogo'
+import { Tooltip } from '@/components/ui/tooltip'
+import type { ReactElement, ReactNode } from 'react'
 
 interface Job {
     id: string
@@ -172,45 +174,60 @@ export function JobCard({ job, onViewDescription, onApply, isApplying = false, c
     }
 
     const getApplicationStatusDisplay = (status: string) => {
+        const tipByStatus: Record<string, string> = {
+            applied: 'You have applied to this job',
+            shortlisted: 'Your application was shortlisted for the next round',
+            selected: 'You were selected for this role',
+            rejected: 'This application was not selected',
+            pending: 'Your application is under review',
+        }
+        const tip = tipByStatus[status]
+        let badge: ReactNode = null
         switch (status) {
             case 'applied':
-                return (
+                badge = (
                     <span className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-semibold bg-blue-600 text-white border border-blue-500">
                         <CheckCircle className="w-3 h-3" />
                         Applied
                     </span>
                 )
+                break
             case 'shortlisted':
-                return (
+                badge = (
                     <span className="text-xs text-yellow-600 dark:text-yellow-400 font-medium flex items-center justify-center gap-1">
                         <Users className="w-3 h-3" />
                         Shortlisted
                     </span>
                 )
+                break
             case 'selected':
-                return (
+                badge = (
                     <span className="text-xs text-green-600 dark:text-green-400 font-medium flex items-center justify-center gap-1">
                         <CheckCircle className="w-3 h-3" />
                         Selected! 🎉
                     </span>
                 )
+                break
             case 'rejected':
-                return (
+                badge = (
                     <span className="text-xs text-red-600 dark:text-red-400 font-medium flex items-center justify-center gap-1">
                         <X className="w-3 h-3" />
                         Not Selected
                     </span>
                 )
+                break
             case 'pending':
-                return (
+                badge = (
                     <span className="text-xs text-purple-600 dark:text-purple-400 font-medium flex items-center justify-center gap-1">
                         <Clock className="w-3 h-3" />
                         Under Review
                     </span>
                 )
+                break
             default:
                 return null
         }
+        return tip ? <Tooltip content={tip}>{badge as ReactElement}</Tooltip> : badge
     }
 
     const getWorkModeBadge = () => {

--- a/components/dashboard/StudentManagementHeader.tsx
+++ b/components/dashboard/StudentManagementHeader.tsx
@@ -1,3 +1,6 @@
+'use client'
+
+import { useMemo, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
 import {
     Search,
@@ -6,13 +9,13 @@ import {
     Calendar,
     UserPlus,
     Upload,
-    X,
     Trash2,
-    GraduationCap
+    GraduationCap,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { getDegreeLabel } from '@/lib/academicHierarchy'
+import { MobileFilterBottomSheet } from '@/components/ui/MobileFilterBottomSheet'
 
 interface StudentManagementHeaderProps {
     totalStudents: number
@@ -40,10 +43,10 @@ interface StudentManagementHeaderProps {
     onBulkUpload: () => void
 }
 
+const selectClass =
+    'w-full px-3 py-2.5 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white text-sm appearance-none'
+
 export function StudentManagementHeader({
-    totalStudents,
-    activeStudents,
-    archivedStudents,
     searchTerm,
     onSearchChange,
     filterStatus,
@@ -63,70 +66,111 @@ export function StudentManagementHeader({
     setShowFilters,
     onClearFilters,
     onAddStudent,
-    onBulkUpload
+    onBulkUpload,
 }: StudentManagementHeaderProps) {
+    const [sheetOpen, setSheetOpen] = useState(false)
+    const [draftStatus, setDraftStatus] = useState(filterStatus)
+    const [draftDegree, setDraftDegree] = useState(selectedDegree)
+    const [draftBranch, setDraftBranch] = useState(selectedBranch)
+    const [draftYear, setDraftYear] = useState(selectedYear)
+    const [draftArchived, setDraftArchived] = useState(includeArchived)
+
+    const activeCount = useMemo(() => {
+        let n = 0
+        if (filterStatus !== 'all') n += 1
+        if (selectedDegree !== 'all') n += 1
+        if (selectedBranch !== 'all') n += 1
+        if (selectedYear !== 'all') n += 1
+        if (includeArchived) n += 1
+        return n
+    }, [filterStatus, selectedDegree, selectedBranch, selectedYear, includeArchived])
+
+    const openSheet = () => {
+        setDraftStatus(filterStatus)
+        setDraftDegree(selectedDegree)
+        setDraftBranch(selectedBranch)
+        setDraftYear(selectedYear)
+        setDraftArchived(includeArchived)
+        setSheetOpen(true)
+    }
+
+    const applySheet = () => {
+        onFilterChange(draftStatus)
+        onDegreeChange(draftDegree)
+        onBranchChange(draftBranch)
+        onYearChange(draftYear)
+        onIncludeArchivedChange(draftArchived)
+        setShowFilters(true)
+    }
+
+    const clearSheet = () => {
+        setDraftStatus('all')
+        setDraftDegree('all')
+        setDraftBranch('all')
+        setDraftYear('all')
+        setDraftArchived(false)
+        onClearFilters()
+    }
+
     return (
         <div className="space-y-6">
-            {/* Search and Filters */}
-            <div className="bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 p-6">
-                {/* Top Row: Search and Action Buttons */}
-                <div className="flex flex-col sm:flex-row gap-3 mb-4">
-                    <div className="flex-1 relative">
-                        <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+            <div className="rounded-xl border border-gray-200 bg-white p-4 dark:border-gray-700 dark:bg-gray-800 sm:p-6">
+                <div className="mb-4 flex flex-col gap-3 sm:flex-row">
+                    <div className="relative flex-1">
+                        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
                         <Input
                             type="text"
                             placeholder="Search students by name, email, or phone..."
                             value={searchTerm}
                             onChange={(e) => onSearchChange(e.target.value)}
-                            className="pl-10 border-gray-200 dark:border-gray-700 focus:border-primary-500 focus:ring-primary-500/20"
+                            className="border-gray-200 pl-10 focus:border-primary-500 focus:ring-primary-500/20 dark:border-gray-700"
                         />
                     </div>
 
-                    <div className="flex gap-2">
+                    <div className="flex flex-wrap gap-2">
                         <Button
                             onClick={onAddStudent}
-                            className="bg-blue-600 hover:bg-blue-700 text-white shadow-sm transition-all duration-200"
+                            className="bg-blue-600 text-white shadow-sm transition-all duration-200 hover:bg-blue-700"
                         >
-                            <UserPlus className="w-4 h-4 mr-2" />
+                            <UserPlus className="mr-2 h-4 w-4" />
                             Add Student
                         </Button>
                         <Button
                             onClick={onBulkUpload}
-                            className="bg-green-600 hover:bg-green-700 text-white shadow-sm transition-all duration-200"
+                            className="bg-green-600 text-white shadow-sm transition-all duration-200 hover:bg-green-700"
                         >
-                            <Upload className="w-4 h-4 mr-2" />
+                            <Upload className="mr-2 h-4 w-4" />
                             Bulk Upload
                         </Button>
                         <Button
                             variant="outline"
                             onClick={() => setShowFilters(!showFilters)}
-                            className="flex items-center gap-2 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 hover:shadow-md"
+                            className="hidden items-center gap-2 border-gray-200 transition-all duration-200 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:hover:border-gray-600 lg:flex"
                         >
-                            <Filter className="w-4 h-4" />
+                            <Filter className="h-4 w-4" />
                             {showFilters ? 'Hide' : 'Show'} Filters
                         </Button>
-                    </div>
-                </div>
-
-                {/* Collapsible Filters Row */}
-                <AnimatePresence>
-                    {showFilters && (
-                        <motion.div
-                            initial={{ opacity: 0, height: 0 }}
-                            animate={{ opacity: 1, height: 'auto' }}
-                            exit={{ opacity: 0, height: 0 }}
-                            className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 pt-4 border-t border-gray-200 dark:border-gray-700 overflow-hidden"
+                        <MobileFilterBottomSheet
+                            open={sheetOpen}
+                            onOpenChange={(open) => {
+                                if (open) openSheet()
+                                else setSheetOpen(false)
+                            }}
+                            activeCount={activeCount}
+                            onApply={applySheet}
+                            onClear={clearSheet}
+                            clearLabel="Reset"
+                            applyLabel="Apply"
                         >
-                            {/* Status Filter */}
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                                    Status
-                                </label>
-                                <div className="relative">
+                            <div className="space-y-4">
+                                <div className="space-y-1.5">
+                                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Status
+                                    </label>
                                     <select
-                                        value={filterStatus}
-                                        onChange={(e) => onFilterChange(e.target.value)}
-                                        className="w-full px-3 py-2 border border-gray-200 dark:border-gray-700 focus:border-primary-500 focus:ring-primary-500/20 text-gray-900 dark:text-white rounded-lg bg-white dark:bg-gray-800 appearance-none"
+                                        value={draftStatus}
+                                        onChange={(e) => setDraftStatus(e.target.value)}
+                                        className={selectClass}
                                     >
                                         <option value="all">All Statuses</option>
                                         <option value="placed">Placed</option>
@@ -134,110 +178,192 @@ export function StudentManagementHeader({
                                         <option value="inactive">Inactive</option>
                                         <option value="pending">Pending</option>
                                     </select>
-                                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700 dark:text-gray-200">
-                                        <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" /></svg>
-                                    </div>
                                 </div>
-                            </div>
-
-                            {/* Degree Filter */}
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                                    Degree
-                                </label>
-                                <div className="relative">
-                                    <GraduationCap className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+                                <div className="space-y-1.5">
+                                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Degree
+                                    </label>
                                     <select
-                                        value={selectedDegree}
-                                        onChange={(e) => onDegreeChange(e.target.value)}
-                                        className="w-full pl-10 pr-8 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors duration-200 appearance-none"
+                                        value={draftDegree}
+                                        onChange={(e) => setDraftDegree(e.target.value)}
+                                        className={selectClass}
                                     >
                                         <option value="all">All Degrees</option>
-                                        {degrees.map(degree => (
-                                            <option key={degree} value={degree}>{getDegreeLabel(degree)}</option>
+                                        {degrees.map((degree) => (
+                                            <option key={degree} value={degree}>
+                                                {getDegreeLabel(degree)}
+                                            </option>
                                         ))}
                                     </select>
-                                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700 dark:text-gray-200">
-                                        <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" /></svg>
-                                    </div>
                                 </div>
-                            </div>
-
-                            {/* Branch Filter */}
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                                    Branch
-                                </label>
-                                <div className="relative">
-                                    <BookOpen className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+                                <div className="space-y-1.5">
+                                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Branch
+                                    </label>
                                     <select
-                                        value={selectedBranch}
-                                        onChange={(e) => onBranchChange(e.target.value)}
-                                        className="w-full pl-10 pr-8 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors duration-200 appearance-none"
+                                        value={draftBranch}
+                                        onChange={(e) => setDraftBranch(e.target.value)}
+                                        className={selectClass}
                                     >
                                         <option value="all">All Branches</option>
-                                        {branches.map(branch => (
-                                            <option key={branch} value={branch}>{branch}</option>
+                                        {branches.map((branch) => (
+                                            <option key={branch} value={branch}>
+                                                {branch}
+                                            </option>
                                         ))}
                                     </select>
-                                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700 dark:text-gray-200">
-                                        <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" /></svg>
-                                    </div>
                                 </div>
-                            </div>
-
-                            {/* Year Filter */}
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                                    Year
-                                </label>
-                                <div className="relative">
-                                    <Calendar className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+                                <div className="space-y-1.5">
+                                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        Year
+                                    </label>
                                     <select
-                                        value={selectedYear}
-                                        onChange={(e) => onYearChange(e.target.value)}
-                                        className="w-full pl-10 pr-8 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors duration-200 appearance-none"
+                                        value={draftYear}
+                                        onChange={(e) => setDraftYear(e.target.value)}
+                                        className={selectClass}
                                     >
                                         <option value="all">All Years</option>
-                                        {years.map(year => (
-                                            <option key={year} value={year}>{year}</option>
+                                        {years.map((year) => (
+                                            <option key={year} value={year}>
+                                                {year}
+                                            </option>
                                         ))}
                                     </select>
-                                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700 dark:text-gray-200">
-                                        <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" /></svg>
-                                    </div>
                                 </div>
-                            </div>
-
-                            {/* Archive Filter */}
-                            <div>
-                                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-                                    View
-                                </label>
-                                <div className="relative">
-                                    <Filter className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
+                                <div className="space-y-1.5">
+                                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                                        View
+                                    </label>
                                     <select
-                                        value={includeArchived ? 'archived' : 'active'}
-                                        onChange={(e) => onIncludeArchivedChange(e.target.value === 'archived')}
-                                        className="w-full pl-10 pr-8 py-2 border border-gray-200 dark:border-gray-700 rounded-lg bg-white dark:bg-gray-800 text-gray-900 dark:text-white focus:ring-2 focus:ring-primary-500 focus:border-transparent transition-colors duration-200 appearance-none"
+                                        value={draftArchived ? 'archived' : 'active'}
+                                        onChange={(e) =>
+                                            setDraftArchived(e.target.value === 'archived')
+                                        }
+                                        className={selectClass}
                                     >
                                         <option value="active">Active Students</option>
                                         <option value="archived">Archived Students</option>
                                     </select>
-                                    <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700 dark:text-gray-200">
-                                        <svg className="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" /></svg>
-                                    </div>
+                                </div>
+                            </div>
+                        </MobileFilterBottomSheet>
+                    </div>
+                </div>
+
+                <AnimatePresence>
+                    {showFilters && (
+                        <motion.div
+                            initial={{ opacity: 0, height: 0 }}
+                            animate={{ opacity: 1, height: 'auto' }}
+                            exit={{ opacity: 0, height: 0 }}
+                            className="hidden overflow-hidden border-t border-gray-200 pt-4 dark:border-gray-700 lg:grid lg:grid-cols-5 lg:gap-4"
+                        >
+                            <div>
+                                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    Status
+                                </label>
+                                <select
+                                    value={filterStatus}
+                                    onChange={(e) => onFilterChange(e.target.value)}
+                                    className={selectClass}
+                                >
+                                    <option value="all">All Statuses</option>
+                                    <option value="placed">Placed</option>
+                                    <option value="unplaced">Unplaced</option>
+                                    <option value="inactive">Inactive</option>
+                                    <option value="pending">Pending</option>
+                                </select>
+                            </div>
+
+                            <div>
+                                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    Degree
+                                </label>
+                                <div className="relative">
+                                    <GraduationCap className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                                    <select
+                                        value={selectedDegree}
+                                        onChange={(e) => onDegreeChange(e.target.value)}
+                                        className={`${selectClass} pl-10`}
+                                    >
+                                        <option value="all">All Degrees</option>
+                                        {degrees.map((degree) => (
+                                            <option key={degree} value={degree}>
+                                                {getDegreeLabel(degree)}
+                                            </option>
+                                        ))}
+                                    </select>
                                 </div>
                             </div>
 
-                            {/* Clear Filters Button */}
-                            <div className="sm:col-span-2 lg:col-span-5 flex justify-end mt-2">
+                            <div>
+                                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    Branch
+                                </label>
+                                <div className="relative">
+                                    <BookOpen className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                                    <select
+                                        value={selectedBranch}
+                                        onChange={(e) => onBranchChange(e.target.value)}
+                                        className={`${selectClass} pl-10`}
+                                    >
+                                        <option value="all">All Branches</option>
+                                        {branches.map((branch) => (
+                                            <option key={branch} value={branch}>
+                                                {branch}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    Year
+                                </label>
+                                <div className="relative">
+                                    <Calendar className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                                    <select
+                                        value={selectedYear}
+                                        onChange={(e) => onYearChange(e.target.value)}
+                                        className={`${selectClass} pl-10`}
+                                    >
+                                        <option value="all">All Years</option>
+                                        {years.map((year) => (
+                                            <option key={year} value={year}>
+                                                {year}
+                                            </option>
+                                        ))}
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div>
+                                <label className="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300">
+                                    View
+                                </label>
+                                <div className="relative">
+                                    <Filter className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+                                    <select
+                                        value={includeArchived ? 'archived' : 'active'}
+                                        onChange={(e) =>
+                                            onIncludeArchivedChange(e.target.value === 'archived')
+                                        }
+                                        className={`${selectClass} pl-10`}
+                                    >
+                                        <option value="active">Active Students</option>
+                                        <option value="archived">Archived Students</option>
+                                    </select>
+                                </div>
+                            </div>
+
+                            <div className="mt-2 flex justify-end lg:col-span-5">
                                 <Button
                                     variant="outline"
                                     onClick={onClearFilters}
-                                    className="border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 hover:shadow-md px-6"
+                                    className="border-gray-200 px-6 transition-all duration-200 hover:border-gray-300 hover:shadow-md dark:border-gray-700 dark:hover:border-gray-600"
                                 >
-                                    <Trash2 className="w-4 h-4 mr-2" />
+                                    <Trash2 className="mr-2 h-4 w-4" />
                                     Clear All
                                 </Button>
                             </div>

--- a/components/dashboard/StudentSidebar.tsx
+++ b/components/dashboard/StudentSidebar.tsx
@@ -25,6 +25,7 @@ import Image from 'next/image'
 import { useLoading } from '@/contexts/LoadingContext'
 import SSOService from '@/services/ssoService'
 import { cn } from '@/lib/utils'
+import { MobileBottomNav, MobileBottomNavAction } from '@/components/ui/MobileBottomNav'
 
 interface NavItem {
     label: string
@@ -335,49 +336,29 @@ export function StudentSidebar({ className = '' }: StudentSidebarProps) {
             </aside>
 
             {/* Mobile Bottom Navigation */}
-            <nav className="student-mobile-nav lg:hidden fixed bottom-0 left-0 right-0 z-50 bg-white/95 dark:bg-[#0f1219]/95 backdrop-blur-md border-t border-gray-200 dark:border-white/10 shadow-[0_-4px_20px_rgba(0,0,0,0.25)] pb-safe">
-                <div className="flex items-stretch justify-around px-1 py-1">
-                    {mobilePrimaryItems.map((item) => {
-                        const active = isItemActive(item.href)
-                        return (
-                            <Link
-                                key={item.href}
-                                href={item.href}
-                                onClick={() => {
-                                    if (!active) startLoading()
-                                }}
-                                className={cn(
-                                    'flex flex-col items-center justify-center gap-0.5 flex-1 py-1.5 rounded-xl transition-colors min-w-0',
-                                    active
-                                        ? 'text-blue-500'
-                                        : 'text-gray-500 dark:text-gray-400'
-                                )}
-                            >
-                                <div
-                                    className={cn(
-                                        'p-1.5 rounded-xl transition-colors',
-                                        active && 'bg-blue-500/15'
-                                    )}
-                                >
-                                    <item.icon className="w-5 h-5" />
-                                </div>
-                                <span className="text-[10px] font-medium truncate max-w-full px-0.5">
-                                    {item.label === 'Applications' ? 'Apps' : item.label === 'Live Jobs' ? 'Jobs' : item.label.split(' ')[0]}
-                                </span>
-                            </Link>
-                        )
-                    })}
-                    <button
+            <MobileBottomNav
+                aria-label="Student mobile navigation"
+                items={mobilePrimaryItems.map((item) => ({
+                    href: item.href,
+                    label: item.label,
+                    shortLabel:
+                        item.label === 'Applications'
+                            ? 'Apps'
+                            : item.label === 'Live Jobs'
+                              ? 'Jobs'
+                              : item.label.split(' ')[0],
+                    icon: item.icon,
+                    active: isItemActive(item.href),
+                    onNavigate: startLoading,
+                }))}
+                trailing={
+                    <MobileBottomNavAction
+                        label="More"
+                        icon={MoreHorizontal}
                         onClick={() => setIsMobileMenuOpen(true)}
-                        className="flex flex-col items-center justify-center gap-0.5 flex-1 py-1.5 rounded-xl text-gray-500 dark:text-gray-400 min-w-0"
-                    >
-                        <div className="p-1.5 rounded-xl">
-                            <MoreHorizontal className="w-5 h-5" />
-                        </div>
-                        <span className="text-[10px] font-medium">More</span>
-                    </button>
-                </div>
-            </nav>
+                    />
+                }
+            />
 
             {/* Mobile More Drawer */}
             <AnimatePresence>

--- a/components/dashboard/UniversitySidebar.tsx
+++ b/components/dashboard/UniversitySidebar.tsx
@@ -21,6 +21,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { apiClient } from '@/lib/api'
 import Image from 'next/image'
 import { useLoading } from '@/contexts/LoadingContext'
+import { MobileBottomNav, MobileBottomNavAction } from '@/components/ui/MobileBottomNav'
 
 interface NavItem {
     label: string
@@ -101,6 +102,7 @@ export function UniversitySidebar({ className = '' }: UniversitySidebarProps) {
     const [imageError, setImageError] = useState(false)
     const pathname = usePathname()
     const { user, logout } = useAuth()
+    const { startLoading } = useLoading()
     const desktopNavRef = useRef<HTMLDivElement>(null)
 
     // Fetch profile data when component mounts
@@ -283,34 +285,17 @@ export function UniversitySidebar({ className = '' }: UniversitySidebarProps) {
             </div>
 
             {/* Mobile Bottom Navigation */}
-            <div className="lg:hidden fixed bottom-0 left-0 right-0 bg-white dark:bg-gray-800 border-t border-gray-200 dark:border-gray-700 z-50 shadow-lg pb-safe" style={{ touchAction: 'none' }}>
-                <div className="flex justify-around items-center py-1.5 px-1 w-full">
-                    {navItems.map((item) => {
-                        const isActive = pathname === item.href
-                        const { startLoading } = useLoading()
-
-                        const handleClick = () => {
-                            if (!isActive) {
-                                startLoading()
-                            }
-                        }
-
-                        return (
-                            <Link
-                                key={item.href}
-                                href={item.href}
-                                onClick={handleClick}
-                                className={`flex items-center justify-center p-2 rounded-lg transition-all duration-200 w-full max-w-[25%] ${isActive
-                                    ? 'text-primary-600 dark:text-primary-400 bg-primary-50 dark:bg-primary-900/20'
-                                    : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white hover:bg-gray-50 dark:hover:bg-gray-700'
-                                    }`}
-                            >
-                                <item.icon className="w-5 h-5 sm:w-6 sm:h-6" />
-                            </Link>
-                        )
-                    })}
-                </div>
-            </div>
+            <MobileBottomNav
+                aria-label="University mobile navigation"
+                items={navItems.map((item) => ({
+                    href: item.href,
+                    label: item.label,
+                    shortLabel: item.label.split(' ')[0],
+                    icon: item.icon,
+                    active: pathname === item.href,
+                    onNavigate: startLoading,
+                }))}
+            />
 
             {/* Mobile Menu Overlay */}
             <AnimatePresence>

--- a/components/events/portal/EventsFilterSidebar.tsx
+++ b/components/events/portal/EventsFilterSidebar.tsx
@@ -38,9 +38,10 @@ function EventsFilterSidebarComponent({
   return (
     <aside
       className={cn(
-                'rounded-2xl border border-gray-200/80 bg-white p-5 shadow-sm',
+        'rounded-2xl border border-gray-200/80 bg-white p-5 shadow-sm',
         'dark:border-gray-700/80 dark:bg-gray-900/80',
-        // Not sticky — stays in document flow so it never overlays the tabs below
+        // Sticky when parent provides sticky wrapper; self-sticky as fallback on desktop
+        'lg:sticky lg:top-20 lg:max-h-[calc(100vh-5.5rem)] lg:overflow-y-auto lg:overscroll-contain',
         className
       )}
     >

--- a/components/jobs/AllJobs.tsx
+++ b/components/jobs/AllJobs.tsx
@@ -12,12 +12,12 @@ import { Search, Loader2, ChevronLeft, ChevronRight } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { MobileFilterBottomSheet } from '@/components/ui/MobileFilterBottomSheet'
+import { StickyFilterPanel } from '@/components/ui/StickyFilterPanel'
 import { JobCard } from '@/components/dashboard/JobCard'
 import { ApplicationModal } from '@/components/dashboard/ApplicationModal'
 import {
   JobsFilterFields,
   EMPTY_JOB_FILTERS,
-  INDUSTRY_OPTIONS,
   toApiDatePosted,
   type JobsFilterValues,
   type DatePostedFilter,
@@ -710,6 +710,7 @@ export function AllJobs() {
                                     onFilterChange={handleDraftFilterChange}
                                     onDatePostedChange={setDraftDatePosted}
                                     dense
+                                    namePrefix="jobs-sheet"
                                 />
                             </MobileFilterBottomSheet>
                             <Button
@@ -908,121 +909,25 @@ export function AllJobs() {
                     )}
                 </div>
 
-                {/* Desktop filter sidebar — sticky, independently scrollable */}
-                <aside className="sticky top-20 hidden max-h-[calc(100vh-5.5rem)] self-start overflow-y-auto overscroll-contain lg:block">
-                    <div className="rounded-2xl border border-gray-200/70 bg-white p-4 shadow-sm dark:border-white/10 dark:bg-[#151b2b]/90">
-                        <div className="mb-4 flex items-center justify-between">
-                            <h2 className="text-base font-semibold text-gray-900 dark:text-white">
-                                Filter Jobs
-                            </h2>
-                            <button
-                                type="button"
-                                onClick={clearFilters}
-                                className="text-xs font-semibold text-blue-500 hover:text-blue-400"
-                            >
-                                Clear All
-                            </button>
-                        </div>
-
-                        <div className="space-y-4 text-sm">
-                            <div>
-                                <p className="mb-2 font-medium text-gray-700 dark:text-gray-200">Job Type</p>
-                                <div className="space-y-1.5">
-                                    {[
-                                        { value: '', label: 'All Types' },
-                                        { value: 'full_time', label: 'Full Time' },
-                                        { value: 'part_time', label: 'Part Time' },
-                                        { value: 'internship', label: 'Internship' },
-                                        { value: 'contract', label: 'Contract' },
-                                    ].map((opt) => (
-                                        <label
-                                            key={opt.value || 'all'}
-                                            className="flex cursor-pointer items-center gap-2 text-gray-600 dark:text-gray-300"
-                                        >
-                                            <input
-                                                type="radio"
-                                                name="job_type_sidebar"
-                                                checked={filters.job_type === opt.value}
-                                                onChange={() => handleFilterChange('job_type', opt.value)}
-                                                className="accent-blue-500"
-                                            />
-                                            {opt.label}
-                                        </label>
-                                    ))}
-                                </div>
-                            </div>
-
-                            <div>
-                                <label className="mb-1.5 block font-medium text-gray-700 dark:text-gray-200">
-                                    Location
-                                </label>
-                                <Input
-                                    placeholder="City, State"
-                                    value={filters.location}
-                                    onChange={(e) => handleFilterChange('location', e.target.value)}
-                                    className="h-9 border-gray-200 bg-white text-sm dark:border-white/10 dark:bg-[#0f1219]"
-                                />
-                            </div>
-
-                            <div>
-                                <label className="mb-1.5 block font-medium text-gray-700 dark:text-gray-200">
-                                    Industry
-                                </label>
-                                <select
-                                    value={filters.industry}
-                                    onChange={(e) => handleFilterChange('industry', e.target.value)}
-                                    className="h-9 w-full rounded-lg border border-gray-200 bg-white px-2 text-sm text-gray-900 dark:border-white/10 dark:bg-[#0f1219] dark:text-white"
-                                >
-                                    {INDUSTRY_OPTIONS.filter((o) =>
-                                        ['', 'Technology', 'Finance', 'Healthcare', 'Education', 'Manufacturing'].includes(
-                                            o.value
-                                        )
-                                    ).map((opt) => (
-                                        <option key={opt.value || 'all'} value={opt.value}>
-                                            {opt.label}
-                                        </option>
-                                    ))}
-                                </select>
-                            </div>
-
-                            <div>
-                                <p className="mb-2 font-medium text-gray-700 dark:text-gray-200">Date Posted</p>
-                                <div className="space-y-1.5">
-                                    {[
-                                        { value: 'all', label: 'Anytime' },
-                                        { value: '24h', label: 'Last 24 hours' },
-                                        { value: '7d', label: 'Last 7 days' },
-                                        { value: '30d', label: 'Last 30 days' },
-                                    ].map((opt) => (
-                                        <label
-                                            key={opt.value}
-                                            className="flex cursor-pointer items-center gap-2 text-gray-600 dark:text-gray-300"
-                                        >
-                                            <input
-                                                type="radio"
-                                                name="date_posted_sidebar"
-                                                checked={datePostedFilter === opt.value}
-                                                onChange={() =>
-                                                    handleDesktopDateChange(opt.value as DatePostedFilter)
-                                                }
-                                                className="accent-blue-500"
-                                            />
-                                            {opt.label}
-                                        </label>
-                                    ))}
-                                </div>
-                            </div>
-
-                            <Button
-                                type="button"
-                                onClick={handleDesktopShowResults}
-                                className="h-10 w-full rounded-xl bg-blue-600 font-semibold text-white hover:bg-blue-500"
-                            >
-                                Show Results
-                            </Button>
-                        </div>
+                <StickyFilterPanel title="Filter Jobs" onClear={clearFilters}>
+                    <div className="space-y-4 text-sm">
+                        <JobsFilterFields
+                            filters={filters}
+                            datePosted={datePostedFilter}
+                            onFilterChange={handleFilterChange}
+                            onDatePostedChange={handleDesktopDateChange}
+                            dense
+                            namePrefix="jobs-sidebar"
+                        />
+                        <Button
+                            type="button"
+                            onClick={handleDesktopShowResults}
+                            className="h-10 w-full rounded-xl bg-blue-600 font-semibold text-white hover:bg-blue-500"
+                        >
+                            Show Results
+                        </Button>
                     </div>
-                </aside>
+                </StickyFilterPanel>
             </div>
 
             {showApplicationModal && selectedJob && (

--- a/components/jobs/JobsFilterFields.tsx
+++ b/components/jobs/JobsFilterFields.tsx
@@ -83,6 +83,8 @@ interface JobsFilterFieldsProps {
   className?: string
   /** Compact spacing for bottom sheet / sidebar. */
   dense?: boolean
+  /** Prefix radio input names so sheet + sidebar can coexist. */
+  namePrefix?: string
 }
 
 function selectClassName(dense?: boolean) {
@@ -101,6 +103,7 @@ function JobsFilterFieldsComponent({
   onDatePostedChange,
   className,
   dense,
+  namePrefix = "jobs",
 }: JobsFilterFieldsProps) {
   return (
     <div className={cn("space-y-4", className)}>
@@ -114,7 +117,7 @@ function JobsFilterFieldsComponent({
             >
               <input
                 type="radio"
-                name="job_type_sheet"
+                name={`${namePrefix}_job_type`}
                 checked={filters.job_type === opt.value}
                 onChange={() => onFilterChange("job_type", opt.value)}
                 className="accent-blue-500"
@@ -252,7 +255,7 @@ function JobsFilterFieldsComponent({
             >
               <input
                 type="radio"
-                name="date_posted_sheet"
+                name={`${namePrefix}_date_posted`}
                 checked={datePosted === opt.value}
                 onChange={() => onDatePostedChange(opt.value)}
                 className="accent-blue-500"

--- a/components/practice/PracticeDashboard.tsx
+++ b/components/practice/PracticeDashboard.tsx
@@ -10,7 +10,8 @@ import { toast } from 'react-hot-toast'
 import { PracticeExam } from './PracticeExam'
 import { AssessmentDetailsModal } from './AssessmentDetailsModal'
 import { ResultReport } from './ResultReport'
-import { PracticeFilter, PracticeCategory } from './PracticeFilter'
+import { PracticeFilter, PracticeFilterSidebar, PracticeCategory } from './PracticeFilter'
+import { Tooltip } from '@/components/ui/tooltip'
 import { usePracticeModules, useJobAssessments } from '@/hooks/usePractice'
 import { useStudentProfile } from '@/hooks/useStudentProfile'
 import { PracticeModule, SubmitAttemptResponse, JobAssessment } from '@/types/practice'
@@ -315,186 +316,198 @@ export function PracticeDashboard() {
                 </div>
             </div>
 
-            {/* Filter Section - Updated with better styling */}
-            <PracticeFilter
-                searchTerm={searchTerm}
-                onSearchChange={setSearchTerm}
-                selectedCategory={selectedCategory}
-                onCategoryChange={setSelectedCategory}
-                selectedUniversities={selectedUniversities}
-                onUniversitiesChange={setSelectedUniversities}
-                selectedBranches={selectedBranches}
-                onBranchesChange={setSelectedBranches}
-                onSearch={handleSearch}
-                onClearFilters={handleClearFilters}
-            />
+            <div className="lg:grid lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start lg:gap-4">
+                <div className="min-w-0 space-y-6">
+                    <PracticeFilter
+                        searchTerm={searchTerm}
+                        onSearchChange={setSearchTerm}
+                        selectedCategory={selectedCategory}
+                        onCategoryChange={setSelectedCategory}
+                        selectedUniversities={selectedUniversities}
+                        onUniversitiesChange={setSelectedUniversities}
+                        selectedBranches={selectedBranches}
+                        onBranchesChange={setSelectedBranches}
+                        onSearch={handleSearch}
+                        onClearFilters={handleClearFilters}
+                    />
 
-            {/* Stats Cards */}
-            <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                {/* ... stats ... */}
-                {[
-                    {
-                        label: 'Available Tests',
-                        value: filteredModules.length.toString(),
-                        icon: Brain,
-                        color: 'text-blue-600',
-                        bgColor: 'bg-gradient-to-r from-blue-50/80 to-indigo-50/80 dark:from-blue-900/20 dark:to-indigo-900/20',
-                        borderColor: 'border-blue-200/50 dark:border-blue-700/50'
-                    },
-                    {
-                        label: 'Total Questions',
-                        value: filteredModules.reduce((sum, module) => sum + module.questions_count, 0).toString(),
-                        icon: Clock,
-                        color: 'text-green-600',
-                        bgColor: 'bg-gradient-to-r from-green-50/80 to-emerald-50/80 dark:from-green-900/20 dark:to-emerald-900/20',
-                        borderColor: 'border-green-200/50 dark:border-green-700/50'
-                    },
-                    {
-                        label: 'Practice Areas',
-                        value: new Set(filteredModules.map(m => m.role)).size.toString(),
-                        icon: Trophy,
-                        color: 'text-purple-600',
-                        bgColor: 'bg-gradient-to-r from-purple-50/80 to-violet-50/80 dark:from-purple-900/20 dark:to-violet-900/20',
-                        borderColor: 'border-purple-200/50 dark:border-purple-700/50'
-                    }
-                ].map((stat, index) => (
-                    <motion.div
-                        key={stat.label}
-                        initial={{ opacity: 0, y: 20 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        transition={{ duration: 0.6, delay: index * 0.1 }}
-                        className="w-full"
-                    >
-                        <div className="block group w-full">
-                            <div className={`p-4 rounded-xl border backdrop-blur-sm hover:shadow-md transition-all duration-200 hover:-translate-y-1 w-full ${stat.bgColor} ${stat.borderColor}`}>
-                                <div className="flex items-center justify-between">
-                                    <div className="flex-1">
-                                        <p className="text-sm font-medium text-gray-600 dark:text-gray-400 mb-1">
-                                            {stat.label}
-                                        </p>
-                                        <p className="text-2xl font-bold text-gray-900 dark:text-white group-hover:scale-105 transition-transform duration-200">
-                                            {isLoading ? (
-                                                <div className="animate-pulse bg-gray-300 dark:bg-gray-600 h-8 w-16 rounded"></div>
-                                            ) : (
-                                                stat.value
-                                            )}
-                                        </p>
+                    <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+                        {[
+                            {
+                                label: 'Available Tests',
+                                value: filteredModules.length.toString(),
+                                icon: Brain,
+                                tooltip: 'Number of practice modules matching your current filters',
+                                color: 'text-blue-600',
+                                bgColor: 'bg-gradient-to-r from-blue-50/80 to-indigo-50/80 dark:from-blue-900/20 dark:to-indigo-900/20',
+                                borderColor: 'border-blue-200/50 dark:border-blue-700/50'
+                            },
+                            {
+                                label: 'Total Questions',
+                                value: filteredModules.reduce((sum, module) => sum + module.questions_count, 0).toString(),
+                                icon: Clock,
+                                tooltip: 'Sum of questions across filtered practice modules',
+                                color: 'text-green-600',
+                                bgColor: 'bg-gradient-to-r from-green-50/80 to-emerald-50/80 dark:from-green-900/20 dark:to-emerald-900/20',
+                                borderColor: 'border-green-200/50 dark:border-green-700/50'
+                            },
+                            {
+                                label: 'Practice Areas',
+                                value: new Set(filteredModules.map(m => m.role)).size.toString(),
+                                icon: Trophy,
+                                tooltip: 'Distinct roles or focus areas in the filtered set',
+                                color: 'text-purple-600',
+                                bgColor: 'bg-gradient-to-r from-purple-50/80 to-violet-50/80 dark:from-purple-900/20 dark:to-violet-900/20',
+                                borderColor: 'border-purple-200/50 dark:border-purple-700/50'
+                            }
+                        ].map((stat, index) => (
+                            <motion.div
+                                key={stat.label}
+                                initial={{ opacity: 0, y: 20 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.6, delay: index * 0.1 }}
+                                className="w-full"
+                            >
+                                <Tooltip content={stat.tooltip}>
+                                    <div className={`group w-full cursor-default rounded-xl border p-4 backdrop-blur-sm transition-all duration-200 hover:-translate-y-1 hover:shadow-md ${stat.bgColor} ${stat.borderColor}`}>
+                                        <div className="flex items-center justify-between">
+                                            <div className="flex-1">
+                                                <p className="mb-1 text-sm font-medium text-gray-600 dark:text-gray-400">
+                                                    {stat.label}
+                                                </p>
+                                                <p className="text-2xl font-bold text-gray-900 transition-transform duration-200 group-hover:scale-105 dark:text-white">
+                                                    {isLoading ? (
+                                                        <span className="inline-block h-8 w-16 animate-pulse rounded bg-gray-300 dark:bg-gray-600" />
+                                                    ) : (
+                                                        stat.value
+                                                    )}
+                                                </p>
+                                            </div>
+                                            <div className="rounded-lg bg-white/60 p-3 shadow-sm backdrop-blur-sm transition-transform duration-200 group-hover:scale-110 dark:bg-gray-800/60">
+                                                <stat.icon className={`h-6 w-6 ${stat.color}`} />
+                                            </div>
+                                        </div>
                                     </div>
-                                    <div className="p-3 rounded-lg bg-white/60 dark:bg-gray-800/60 backdrop-blur-sm shadow-sm group-hover:scale-110 transition-transform duration-200">
-                                        <stat.icon className={`w-6 h-6 ${stat.color}`} />
+                                </Tooltip>
+                            </motion.div>
+                        ))}
+                    </div>
+
+                    {jobAssessments && jobAssessments.length > 0 && (
+                        <div className="rounded-xl border border-gray-200/50 bg-white/80 shadow-sm backdrop-blur-sm transition-all duration-300 hover:shadow-md dark:border-gray-700/50 dark:bg-gray-800/80">
+                            <div className="flex items-center gap-2 border-b border-gray-200/50 p-6 dark:border-gray-700/50">
+                                <Briefcase className="h-5 w-5 text-primary-600" />
+                                <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                                    Hiring Assessments
+                                </h2>
+                            </div>
+                            <div className="p-6">
+                                {jobAssessmentsLoading ? (
+                                    <CardSkeleton count={3} />
+                                ) : (
+                                    <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+                                        {jobAssessments.map((assessment, index) => (
+                                            <motion.div
+                                                key={assessment.id}
+                                                initial={{ opacity: 0, y: 20 }}
+                                                animate={{ opacity: 1, y: 0 }}
+                                                transition={{ delay: index * 0.1 }}
+                                            >
+                                                <JobAssessmentCard
+                                                    assessment={assessment}
+                                                    cardIndex={index}
+                                                    onViewDetails={() => handleViewJobAssessmentDetails(assessment)}
+                                                    onStart={() => handleStartJobAssessment(assessment)}
+                                                />
+                                            </motion.div>
+                                        ))}
                                     </div>
-                                </div>
+                                )}
                             </div>
-                        </div>
-                    </motion.div>
-                ))}
-            </div>
-
-            {/* Job Assessments Section */}
-            {jobAssessments && jobAssessments.length > 0 && (
-                <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-300">
-                    <div className="p-6 border-b border-gray-200/50 dark:border-gray-700/50 flex items-center gap-2">
-                        <Briefcase className="w-5 h-5 text-primary-600" />
-                        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-                            Hiring Assessments
-                        </h2>
-                    </div>
-                    <div className="p-6">
-                        {jobAssessmentsLoading ? (
-                            <CardSkeleton count={3} />
-                        ) : (
-                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                                {jobAssessments.map((assessment, index) => (
-                                    <motion.div
-                                        key={assessment.id}
-                                        initial={{ opacity: 0, y: 20 }}
-                                        animate={{ opacity: 1, y: 0 }}
-                                        transition={{ delay: index * 0.1 }}
-                                    >
-                                        <JobAssessmentCard
-                                            assessment={assessment}
-                                            cardIndex={index}
-                                            onViewDetails={() => handleViewJobAssessmentDetails(assessment)}
-                                            onStart={() => handleStartJobAssessment(assessment)}
-                                        />
-                                    </motion.div>
-                                ))}
-                            </div>
-                        )}
-                    </div>
-                </div>
-            )}
-
-            {/* Practice Modules Grid */}
-            <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-300">
-                <div className="p-6 border-b border-gray-200/50 dark:border-gray-700/50">
-                    <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-                        Available Practice Tests
-                    </h2>
-                </div>
-                <div className="p-6">
-                    {isLoading ? (
-                        <CardSkeleton count={6} />
-                    ) : error ? (
-                        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-700 rounded-xl p-6">
-                            <h3 className="text-lg font-medium text-red-900 dark:text-red-100 mb-2">
-                                Error Loading Practice Modules
-                            </h3>
-                            <p className="text-red-700 dark:text-red-300">
-                                {error instanceof Error ? error.message : 'Failed to load practice modules'}
-                            </p>
-                        </div>
-                    ) : filteredModules.length > 0 ? (
-                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                            {filteredModules.map((module, index) => (
-                                <motion.div
-                                    key={module.id}
-                                    initial={{ opacity: 0, y: 20 }}
-                                    animate={{ opacity: 1, y: 0 }}
-                                    transition={{ delay: index * 0.1 }}
-                                >
-                                    <PracticeCard
-                                        module={module}
-                                        onStart={() => handleStartExam(module)}
-                                        onViewResults={() => {
-                                            const result = moduleResults.get(module.id)
-                                            if (result) {
-                                                handleViewResults(module, result)
-                                            }
-                                        }}
-                                        isSubmitted={submittedModules.has(module.id)}
-                                        result={moduleResults.get(module.id)}
-                                    />
-                                </motion.div>
-                            ))}
-                        </div>
-                    ) : (
-                        <div className="bg-gray-50/50 dark:bg-gray-800/50 backdrop-blur-sm rounded-xl border border-gray-200/50 dark:border-gray-700/50 p-12 text-center">
-                            <Brain className="w-16 h-16 text-gray-400 mx-auto mb-4" />
-                            <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
-                                {searchTerm || selectedCategory !== 'all'
-                                    ? 'No Practice Modules Found'
-                                    : 'No Practice Modules Available'
-                                }
-                            </h3>
-                            <p className="text-gray-600 dark:text-gray-400">
-                                {searchTerm || selectedCategory !== 'all'
-                                    ? 'Try adjusting your search terms or filters to find more practice tests.'
-                                    : 'Check back later for new practice tests and assessments.'
-                                }
-                            </p>
-                            {(searchTerm || selectedCategory !== 'all') && (
-                                <Button
-                                    onClick={handleClearFilters}
-                                    variant="outline"
-                                    className="mt-4 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all duration-200"
-                                >
-                                    Clear Filters
-                                </Button>
-                            )}
                         </div>
                     )}
+
+                    <div className="rounded-xl border border-gray-200/50 bg-white/80 shadow-sm backdrop-blur-sm transition-all duration-300 hover:shadow-md dark:border-gray-700/50 dark:bg-gray-800/80">
+                        <div className="border-b border-gray-200/50 p-6 dark:border-gray-700/50">
+                            <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+                                Available Practice Tests
+                            </h2>
+                        </div>
+                        <div className="p-6">
+                            {isLoading ? (
+                                <CardSkeleton count={6} />
+                            ) : error ? (
+                                <div className="rounded-xl border border-red-200 bg-red-50 p-6 dark:border-red-700 dark:bg-red-900/20">
+                                    <h3 className="mb-2 text-lg font-medium text-red-900 dark:text-red-100">
+                                        Error Loading Practice Modules
+                                    </h3>
+                                    <p className="text-red-700 dark:text-red-300">
+                                        {error instanceof Error ? error.message : 'Failed to load practice modules'}
+                                    </p>
+                                </div>
+                            ) : filteredModules.length > 0 ? (
+                                <div className="grid grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+                                    {filteredModules.map((module, index) => (
+                                        <motion.div
+                                            key={module.id}
+                                            initial={{ opacity: 0, y: 20 }}
+                                            animate={{ opacity: 1, y: 0 }}
+                                            transition={{ delay: index * 0.1 }}
+                                        >
+                                            <PracticeCard
+                                                module={module}
+                                                onStart={() => handleStartExam(module)}
+                                                onViewResults={() => {
+                                                    const result = moduleResults.get(module.id)
+                                                    if (result) {
+                                                        handleViewResults(module, result)
+                                                    }
+                                                }}
+                                                isSubmitted={submittedModules.has(module.id)}
+                                                result={moduleResults.get(module.id)}
+                                            />
+                                        </motion.div>
+                                    ))}
+                                </div>
+                            ) : (
+                                <div className="rounded-xl border border-gray-200/50 bg-gray-50/50 p-12 text-center backdrop-blur-sm dark:border-gray-700/50 dark:bg-gray-800/50">
+                                    <Brain className="mx-auto mb-4 h-16 w-16 text-gray-400" />
+                                    <h3 className="mb-2 text-lg font-medium text-gray-900 dark:text-white">
+                                        {searchTerm || selectedCategory !== 'all'
+                                            ? 'No Practice Modules Found'
+                                            : 'No Practice Modules Available'
+                                        }
+                                    </h3>
+                                    <p className="text-gray-600 dark:text-gray-400">
+                                        {searchTerm || selectedCategory !== 'all'
+                                            ? 'Try adjusting your search terms or filters to find more practice tests.'
+                                            : 'Check back later for new practice tests and assessments.'
+                                        }
+                                    </p>
+                                    {(searchTerm || selectedCategory !== 'all') && (
+                                        <Button
+                                            onClick={handleClearFilters}
+                                            variant="outline"
+                                            className="mt-4 transition-all duration-200 hover:bg-gray-50 dark:hover:bg-gray-700"
+                                        >
+                                            Clear Filters
+                                        </Button>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                    </div>
                 </div>
+
+                <PracticeFilterSidebar
+                    selectedCategory={selectedCategory}
+                    onCategoryChange={setSelectedCategory}
+                    selectedUniversities={selectedUniversities}
+                    onUniversitiesChange={setSelectedUniversities}
+                    selectedBranches={selectedBranches}
+                    onBranchesChange={setSelectedBranches}
+                    onClearFilters={handleClearFilters}
+                />
             </div>
             <AssessmentDetailsModal
                 isOpen={showDetailsModal}

--- a/components/practice/PracticeFilter.tsx
+++ b/components/practice/PracticeFilter.tsx
@@ -1,267 +1,451 @@
 "use client"
 
-import { useState } from 'react'
-import { motion } from 'framer-motion'
-import { Search, Filter, X, Brain, MessageCircle, Code, Trophy, GraduationCap } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
-import { useStudentProfile } from '@/hooks/useStudentProfile'
-import { useUniversities } from '@/hooks/useUniversities'
-import { useBranches } from '@/hooks/useLookup'
-import { MultiSelectDropdown, MultiSelectOption } from '@/components/ui/MultiSelectDropdown'
+import { useMemo, useState } from "react"
+import {
+  Search,
+  Brain,
+  MessageCircle,
+  Code,
+  Trophy,
+  GraduationCap,
+  X,
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { StickyFilterPanel } from "@/components/ui/StickyFilterPanel"
+import { MobileFilterBottomSheet } from "@/components/ui/MobileFilterBottomSheet"
+import { useStudentProfile } from "@/hooks/useStudentProfile"
+import { useUniversities } from "@/hooks/useUniversities"
+import { useBranches } from "@/hooks/useLookup"
+import {
+  MultiSelectDropdown,
+  MultiSelectOption,
+} from "@/components/ui/MultiSelectDropdown"
+import { cn } from "@/lib/utils"
 
-export type PracticeCategory = 'all' | 'ai-mock-tests' | 'ai-mock-interviews' | 'coding-practice' | 'challenges-engagement'
+export type PracticeCategory =
+  | "all"
+  | "ai-mock-tests"
+  | "ai-mock-interviews"
+  | "coding-practice"
+  | "challenges-engagement"
 
-interface PracticeFilterProps {
-    searchTerm: string
-    onSearchChange: (value: string) => void
-    selectedCategory: PracticeCategory
-    onCategoryChange: (category: PracticeCategory) => void
-    selectedUniversities: string[]
-    onUniversitiesChange: (universities: string[]) => void
-    selectedBranches: string[]
-    onBranchesChange: (branches: string[]) => void
-    onSearch: () => void
-    onClearFilters: () => void
+export interface PracticeFilterProps {
+  searchTerm: string
+  onSearchChange: (value: string) => void
+  selectedCategory: PracticeCategory
+  onCategoryChange: (category: PracticeCategory) => void
+  selectedUniversities: string[]
+  onUniversitiesChange: (universities: string[]) => void
+  selectedBranches: string[]
+  onBranchesChange: (branches: string[]) => void
+  onSearch: () => void
+  onClearFilters: () => void
 }
 
-const categories = [
-    {
-        id: 'all' as PracticeCategory,
-        label: 'All Practice',
-        icon: Brain,
-        description: 'View all practice materials',
-        color: 'from-blue-500 to-purple-600'
-    },
-    {
-        id: 'ai-mock-tests' as PracticeCategory,
-        label: 'AI-Powered Mock Tests',
-        icon: Brain,
-        description: 'Comprehensive mock tests with AI evaluation',
-        color: 'from-rose-500 to-pink-600'
-    },
-    {
-        id: 'ai-mock-interviews' as PracticeCategory,
-        label: 'AI-Powered Mock Interviews',
-        icon: MessageCircle,
-        description: 'Practice interviews with AI feedback',
-        color: 'from-green-500 to-teal-600'
-    },
-    {
-        id: 'coding-practice' as PracticeCategory,
-        label: 'Coding Practice',
-        icon: Code,
-        description: 'Programming challenges and coding exercises',
-        color: 'from-orange-500 to-red-600'
-    },
-    {
-        id: 'challenges-engagement' as PracticeCategory,
-        label: 'Challenges & Engagement',
-        icon: Trophy,
-        description: 'Interactive challenges and engagement activities',
-        color: 'from-purple-500 to-indigo-600'
-    }
+const categories: {
+  id: PracticeCategory
+  label: string
+  shortLabel: string
+  icon: typeof Brain
+  description: string
+}[] = [
+  {
+    id: "all",
+    label: "All Practice",
+    shortLabel: "All",
+    icon: Brain,
+    description: "View all practice materials",
+  },
+  {
+    id: "ai-mock-tests",
+    label: "AI Mock Tests",
+    shortLabel: "Tests",
+    icon: Brain,
+    description: "Mock tests with AI evaluation",
+  },
+  {
+    id: "ai-mock-interviews",
+    label: "AI Interviews",
+    shortLabel: "Interviews",
+    icon: MessageCircle,
+    description: "Practice interviews with feedback",
+  },
+  {
+    id: "coding-practice",
+    label: "Coding Practice",
+    shortLabel: "Coding",
+    icon: Code,
+    description: "Programming challenges",
+  },
+  {
+    id: "challenges-engagement",
+    label: "Challenges",
+    shortLabel: "Challenges",
+    icon: Trophy,
+    description: "Engagement activities",
+  },
 ]
 
+interface FilterFieldsProps {
+  category: PracticeCategory
+  onCategoryChange: (c: PracticeCategory) => void
+  universities: string[]
+  onUniversitiesChange: (v: string[]) => void
+  branches: string[]
+  onBranchesChange: (v: string[]) => void
+  universityOptions: MultiSelectOption[]
+  branchOptions: MultiSelectOption[]
+  universitiesLoading: boolean
+  profileInstitution?: string
+  profileBranch?: string
+  dense?: boolean
+}
 
-export function PracticeFilter({
-    searchTerm,
-    onSearchChange,
-    selectedCategory,
-    onCategoryChange,
-    selectedUniversities,
-    onUniversitiesChange,
-    selectedBranches,
-    onBranchesChange,
-    onSearch,
-    onClearFilters
-}: PracticeFilterProps) {
-    const [showFilters, setShowFilters] = useState(false)
-    const { profile } = useStudentProfile()
-    const { data: universities, isLoading: universitiesLoading } = useUniversities()
-    const { data: branches, loading: branchesLoading } = useBranches({ limit: 1000 })
-    
-    const branchMultiSelectOptions: MultiSelectOption[] = branches.map((branch) => ({
+function PracticeFilterFields({
+  category,
+  onCategoryChange,
+  universities,
+  onUniversitiesChange,
+  branches,
+  onBranchesChange,
+  universityOptions,
+  branchOptions,
+  universitiesLoading,
+  profileInstitution,
+  profileBranch,
+  dense = false,
+}: FilterFieldsProps) {
+  return (
+    <div className={cn("space-y-5", dense && "space-y-4")}>
+      <section>
+        <h3 className="mb-2.5 text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+          Category
+        </h3>
+        <div className="flex flex-wrap gap-2">
+          {categories.map((cat) => {
+            const Icon = cat.icon
+            const selected = category === cat.id
+            return (
+              <button
+                key={cat.id}
+                type="button"
+                onClick={() => onCategoryChange(cat.id)}
+                title={cat.description}
+                className={cn(
+                  "inline-flex min-h-[40px] items-center gap-1.5 rounded-full border px-3 py-2 text-sm font-medium transition-all",
+                  selected
+                    ? "border-blue-500/40 bg-blue-600 text-white shadow-sm shadow-blue-500/20"
+                    : "border-gray-200 bg-gray-50 text-gray-700 hover:border-gray-300 hover:bg-gray-100 dark:border-white/10 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10"
+                )}
+              >
+                <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span>{dense ? cat.shortLabel : cat.label}</span>
+              </button>
+            )
+          })}
+        </div>
+      </section>
+
+      <section className="space-y-3 border-t border-gray-200/70 pt-4 dark:border-white/10">
+        <h3 className="text-xs font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400">
+          Audience
+        </h3>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              University
+            </label>
+            <MultiSelectDropdown
+              options={universityOptions}
+              selectedValues={universities}
+              onSelectionChange={onUniversitiesChange}
+              placeholder="Select universities..."
+              disabled={universitiesLoading}
+              className="w-full"
+            />
+          </div>
+          <div className="space-y-1.5">
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              Branch
+            </label>
+            <MultiSelectDropdown
+              options={branchOptions}
+              selectedValues={branches}
+              onSelectionChange={onBranchesChange}
+              placeholder="Select branches..."
+              className="w-full"
+            />
+          </div>
+        </div>
+      </section>
+
+      <div className="rounded-xl border border-blue-200/60 bg-blue-50/80 p-3 dark:border-blue-700/40 dark:bg-blue-900/20">
+        <div className="mb-1 flex items-center gap-2">
+          <GraduationCap className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+          <span className="text-xs font-semibold text-blue-900 dark:text-blue-100">
+            Smart filtering
+          </span>
+        </div>
+        <p className="text-xs leading-relaxed text-blue-700 dark:text-blue-300">
+          Results also respect your profile
+          {profileInstitution || profileBranch
+            ? ` (${[profileInstitution, profileBranch].filter(Boolean).join(" · ")})`
+            : ""}
+          . Manual filters narrow further.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+function usePracticeFilterOptions() {
+  const { profile } = useStudentProfile()
+  const { data: universities, isLoading: universitiesLoading } = useUniversities()
+  const { data: branches } = useBranches({ limit: 1000 })
+
+  const universityOptions: MultiSelectOption[] = useMemo(
+    () =>
+      universities.map((uni) => ({
+        id: uni.id,
+        label: uni.university_name,
+        value: uni.id,
+      })),
+    [universities]
+  )
+
+  const branchOptions: MultiSelectOption[] = useMemo(
+    () =>
+      branches.map((branch) => ({
         id: branch.id,
         label: branch.name,
         value: branch.name,
-    }))
-    // Convert universities to MultiSelectOption format
-    const universityOptions: MultiSelectOption[] = universities.map(uni => ({
-        id: uni.id,
-        label: uni.university_name,
-        value: uni.id
-    }))
+      })),
+    [branches]
+  )
 
-    return (
-        <div className="bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-xl border border-gray-200/50 dark:border-gray-700/50 shadow-sm hover:shadow-md transition-all duration-300 p-6">
-            {/* Search Bar */}
-            <div className="flex flex-col sm:flex-row gap-3 mb-4">
-                <div className="flex-1 relative">
-                    <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 w-4 h-4" />
-                    <Input
-                        type="text"
-                        placeholder="Search practice tests by title, role, or skills..."
-                        value={searchTerm}
-                        onChange={(e) => onSearchChange(e.target.value)}
-                        onKeyPress={(e) => e.key === 'Enter' && onSearch()}
-                        className="pl-10 border-gray-200 dark:border-gray-700 focus:border-primary-500 focus:ring-primary-500/20 bg-white dark:bg-gray-700"
-                    />
-                </div>
-                <Button
-                    variant="outline"
-                    onClick={() => setShowFilters(!showFilters)}
-                    className="flex items-center gap-2 border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-all duration-200 hover:shadow-md w-full sm:w-auto hover:bg-gray-50 dark:hover:bg-gray-700"
-                >
-                    <Filter className="w-4 h-4" />
-                    {showFilters ? 'Hide' : 'Show'} Filters
-                </Button>
-                <Button
-                    onClick={onSearch}
-                    className="bg-gradient-to-r from-primary-500 to-primary-600 hover:from-primary-600 hover:to-primary-700 text-white font-semibold px-6 h-10 transition-all duration-200 hover:shadow-md w-full sm:w-auto"
-                >
-                    Search
-                </Button>
-            </div>
+  return {
+    profile,
+    universityOptions,
+    branchOptions,
+    universitiesLoading,
+  }
+}
 
-            {/* Category Filters */}
-            {showFilters && (
-                <motion.div
-                    initial={{ opacity: 0, height: 0 }}
-                    animate={{ opacity: 1, height: 'auto' }}
-                    exit={{ opacity: 0, height: 0 }}
-                    className="pt-4 border-t border-gray-200/50 dark:border-gray-700/50"
-                >
-                    <div className="space-y-4">
-                        <div className="flex items-center justify-between">
-                            <h3 className="text-lg font-semibold text-gray-900 dark:text-white">
-                                Practice Categories
-                            </h3>
-                            <Button
-                                variant="outline"
-                                size="sm"
-                                onClick={onClearFilters}
-                                className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all duration-200"
-                            >
-                                <X className="w-4 h-4 mr-1" />
-                                Clear All
-                            </Button>
-                        </div>
-                        
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
-                            {categories.map((category) => {
-                                const Icon = category.icon
-                                const isSelected = selectedCategory === category.id
-                                
-                                return (
-                                    <motion.button
-                                        key={category.id}
-                                        onClick={() => onCategoryChange(category.id)}
-                                        whileHover={{ scale: 1.02 }}
-                                        whileTap={{ scale: 0.98 }}
-                                        className={`p-4 rounded-xl border-2 transition-all duration-200 text-left hover:-translate-y-1 ${
-                                            isSelected
-                                                ? `bg-gradient-to-r ${category.color} text-white border-transparent shadow-lg`
-                                                : 'bg-white/60 dark:bg-gray-700/60 backdrop-blur-sm border-gray-200/50 dark:border-gray-600/50 hover:border-gray-300 dark:hover:border-gray-500 text-gray-900 dark:text-white hover:shadow-md'
-                                        }`}
-                                    >
-                                        <div className="flex items-center gap-3 mb-2">
-                                            <div className={`p-2 rounded-lg ${
-                                                isSelected 
-                                                    ? 'bg-white/20' 
-                                                    : 'bg-gray-100 dark:bg-gray-600'
-                                            }`}>
-                                                <Icon className={`w-5 h-5 ${
-                                                    isSelected 
-                                                        ? 'text-white' 
-                                                        : 'text-gray-600 dark:text-gray-300'
-                                                }`} />
-                                            </div>
-                                            <span className="font-medium text-sm">
-                                                {category.label}
-                                            </span>
-                                        </div>
-                                        <p className={`text-xs ${
-                                            isSelected 
-                                                ? 'text-white/90' 
-                                                : 'text-gray-500 dark:text-gray-400'
-                                        }`}>
-                                            {category.description}
-                                        </p>
-                                    </motion.button>
-                                )
-                            })}
-                        </div>
-                        
-                        {/* University and Branch Filters */}
-                        <div className="pt-4 border-t border-gray-200/50 dark:border-gray-700/50">
-                            <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-4">
-                                Additional Filters
-                            </h3>
-                            
-                            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                                {/* University Filter */}
-                                <div className="space-y-2">
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                                        Filter by University
-                                    </label>
-                                    <MultiSelectDropdown
-                                        options={universityOptions}
-                                        selectedValues={selectedUniversities}
-                                        onSelectionChange={onUniversitiesChange}
-                                        placeholder="Select universities..."
-                                        disabled={universitiesLoading}
-                                        className="w-full"
-                                    />
-                                    {universitiesLoading && (
-                                        <p className="text-xs text-gray-500 dark:text-gray-400">
-                                            Loading universities...
-                                        </p>
-                                    )}
-                                </div>
-                                
-                                {/* Branch Filter */}
-                                <div className="space-y-2">
-                                    <label className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                                        Filter by Branch
-                                    </label>
-                                    <MultiSelectDropdown
-                                        options={branchMultiSelectOptions}
-                                        selectedValues={selectedBranches}
-                                        onSelectionChange={onBranchesChange}
-                                        placeholder="Select branches..."
-                                        className="w-full"
-                                    />
-                                </div>
-                            </div>
-                            
-                            {/* Filter Info */}
-                            <div className="mt-4 p-3 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
-                                <p className="text-sm text-gray-600 dark:text-gray-400">
-                                    <strong>Note:</strong> These filters work in addition to the automatic filtering based on your profile. 
-                                    You can manually select specific universities and branches to see tests targeted to them.
-                                </p>
-                            </div>
-                        </div>
-                        
-                        {/* Automatic Filtering Info */}
-                        <div className="pt-4 border-t border-gray-200/50 dark:border-gray-700/50">
-                            <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 rounded-lg p-4">
-                                <div className="flex items-center gap-2 mb-2">
-                                    <GraduationCap className="w-5 h-5 text-blue-600 dark:text-blue-400" />
-                                    <h4 className="text-sm font-medium text-blue-900 dark:text-blue-100">
-                                        Smart Filtering
-                                    </h4>
-                                </div>
-                                <p className="text-sm text-blue-700 dark:text-blue-300">
-                                    Tests are automatically filtered based on your university ({profile?.institution || 'Not set'}) and branch ({profile?.branch || 'Not set'}). 
-                                    You'll only see tests that are relevant to your academic profile.
-                                </p>
-                            </div>
-                        </div>
-                    </div>
-                </motion.div>
-            )}
+/** Search bar + chips + mobile bottom sheet. Pair with PracticeFilterSidebar on desktop. */
+export function PracticeFilter({
+  searchTerm,
+  onSearchChange,
+  selectedCategory,
+  onCategoryChange,
+  selectedUniversities,
+  onUniversitiesChange,
+  selectedBranches,
+  onBranchesChange,
+  onSearch,
+  onClearFilters,
+}: PracticeFilterProps) {
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [draftCategory, setDraftCategory] = useState(selectedCategory)
+  const [draftUniversities, setDraftUniversities] = useState(selectedUniversities)
+  const [draftBranches, setDraftBranches] = useState(selectedBranches)
+
+  const { profile, universityOptions, branchOptions, universitiesLoading } =
+    usePracticeFilterOptions()
+
+  const activeCount = useMemo(() => {
+    let n = 0
+    if (selectedCategory !== "all") n += 1
+    if (selectedUniversities.length) n += 1
+    if (selectedBranches.length) n += 1
+    return n
+  }, [selectedCategory, selectedUniversities, selectedBranches])
+
+  const openSheet = () => {
+    setDraftCategory(selectedCategory)
+    setDraftUniversities(selectedUniversities)
+    setDraftBranches(selectedBranches)
+    setSheetOpen(true)
+  }
+
+  const applySheet = () => {
+    onCategoryChange(draftCategory)
+    onUniversitiesChange(draftUniversities)
+    onBranchesChange(draftBranches)
+  }
+
+  const clearSheet = () => {
+    setDraftCategory("all")
+    setDraftUniversities([])
+    setDraftBranches([])
+    onClearFilters()
+  }
+
+  const activeChips = categories.filter(
+    (c) => c.id === selectedCategory && c.id !== "all"
+  )
+
+  return (
+    <div className="rounded-2xl border border-gray-200/70 bg-white p-3 shadow-sm dark:border-white/10 dark:bg-[#151b2b]/90 sm:p-4">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          onSearch()
+        }}
+        className="flex gap-2"
+      >
+        <div className="relative min-w-0 flex-1">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" />
+          <Input
+            type="text"
+            placeholder="Search by title, role, or skills..."
+            value={searchTerm}
+            onChange={(e) => onSearchChange(e.target.value)}
+            className="h-10 rounded-xl border-gray-200 bg-white pl-9 text-sm dark:border-white/10 dark:bg-[#0f1219]"
+          />
         </div>
-    )
+        <MobileFilterBottomSheet
+          open={sheetOpen}
+          onOpenChange={(open) => {
+            if (open) openSheet()
+            else setSheetOpen(false)
+          }}
+          activeCount={activeCount}
+          onApply={applySheet}
+          onClear={clearSheet}
+          clearLabel="Reset"
+          applyLabel="Apply"
+        >
+          <PracticeFilterFields
+            category={draftCategory}
+            onCategoryChange={setDraftCategory}
+            universities={draftUniversities}
+            onUniversitiesChange={setDraftUniversities}
+            branches={draftBranches}
+            onBranchesChange={setDraftBranches}
+            universityOptions={universityOptions}
+            branchOptions={branchOptions}
+            universitiesLoading={universitiesLoading}
+            profileInstitution={profile?.institution}
+            profileBranch={profile?.branch}
+            dense
+          />
+        </MobileFilterBottomSheet>
+        <Button
+          type="submit"
+          className="hidden h-10 shrink-0 rounded-xl bg-blue-600 px-5 font-semibold text-white sm:inline-flex"
+        >
+          Search
+        </Button>
+      </form>
+
+      {(activeCount > 0 || searchTerm) && (
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {searchTerm ? (
+            <span className="inline-flex items-center gap-1 rounded-full bg-gray-100 px-2.5 py-1 text-xs font-medium text-gray-700 dark:bg-white/10 dark:text-gray-200">
+              “{searchTerm}”
+              <button
+                type="button"
+                aria-label="Clear search"
+                onClick={() => onSearchChange("")}
+                className="rounded-full p-0.5 hover:bg-gray-200 dark:hover:bg-white/20"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ) : null}
+          {activeChips.map((c) => (
+            <span
+              key={c.id}
+              className="inline-flex items-center gap-1 rounded-full bg-blue-500/15 px-2.5 py-1 text-xs font-medium text-blue-700 dark:text-blue-300"
+            >
+              {c.shortLabel}
+              <button
+                type="button"
+                aria-label={`Remove ${c.label}`}
+                onClick={() => onCategoryChange("all")}
+                className="rounded-full p-0.5 hover:bg-blue-500/20"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </span>
+          ))}
+          {selectedUniversities.length > 0 ? (
+            <span className="rounded-full bg-violet-500/15 px-2.5 py-1 text-xs font-medium text-violet-700 dark:text-violet-300">
+              {selectedUniversities.length} universit
+              {selectedUniversities.length > 1 ? "ies" : "y"}
+            </span>
+          ) : null}
+          {selectedBranches.length > 0 ? (
+            <span className="rounded-full bg-emerald-500/15 px-2.5 py-1 text-xs font-medium text-emerald-700 dark:text-emerald-300">
+              {selectedBranches.length} branch
+              {selectedBranches.length > 1 ? "es" : ""}
+            </span>
+          ) : null}
+          {activeCount > 0 ? (
+            <button
+              type="button"
+              onClick={onClearFilters}
+              className="text-xs font-semibold text-blue-600 hover:text-blue-500 dark:text-blue-400"
+            >
+              Clear all
+            </button>
+          ) : null}
+        </div>
+      )}
+
+      <div className="mt-3 flex gap-1.5 overflow-x-auto pb-0.5 lg:hidden">
+        {categories.map((cat) => {
+          const selected = selectedCategory === cat.id
+          return (
+            <button
+              key={cat.id}
+              type="button"
+              onClick={() => onCategoryChange(cat.id)}
+              className={cn(
+                "whitespace-nowrap rounded-full px-3 py-1.5 text-xs font-semibold transition-all",
+                selected
+                  ? "bg-blue-600 text-white shadow-sm"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-white/5 dark:text-gray-300 dark:hover:bg-white/10"
+              )}
+            >
+              {cat.shortLabel}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+/** Desktop sticky filter sidebar for dual-column PracticeDashboard layout. */
+export function PracticeFilterSidebar({
+  selectedCategory,
+  onCategoryChange,
+  selectedUniversities,
+  onUniversitiesChange,
+  selectedBranches,
+  onBranchesChange,
+  onClearFilters,
+}: Omit<PracticeFilterProps, "searchTerm" | "onSearchChange" | "onSearch">) {
+  const { profile, universityOptions, branchOptions, universitiesLoading } =
+    usePracticeFilterOptions()
+
+  return (
+    <StickyFilterPanel title="Filters" onClear={onClearFilters}>
+      <PracticeFilterFields
+        category={selectedCategory}
+        onCategoryChange={onCategoryChange}
+        universities={selectedUniversities}
+        onUniversitiesChange={onUniversitiesChange}
+        branches={selectedBranches}
+        onBranchesChange={onBranchesChange}
+        universityOptions={universityOptions}
+        branchOptions={branchOptions}
+        universitiesLoading={universitiesLoading}
+        profileInstitution={profile?.institution}
+        profileBranch={profile?.branch}
+      />
+    </StickyFilterPanel>
+  )
 }

--- a/components/student/ui/StudentStatCard.tsx
+++ b/components/student/ui/StudentStatCard.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from 'framer-motion'
 import { cn } from '@/lib/utils'
+import { Tooltip } from '@/components/ui/tooltip'
 import type { LucideIcon } from 'lucide-react'
 
 export interface StudentStatCardProps {
@@ -9,6 +10,8 @@ export interface StudentStatCardProps {
   value: string | number
   icon: LucideIcon
   subtitle?: string
+  /** Explains the metric on hover / long-press. Defaults to label + subtitle. */
+  tooltip?: string
   colorClass?: string
   iconBgClass?: string
   bgClass?: string
@@ -26,6 +29,7 @@ export function StudentStatCard({
   value,
   icon: Icon,
   subtitle,
+  tooltip,
   colorClass = 'text-blue-500',
   iconBgClass = 'bg-blue-500/15',
   bgClass = 'bg-white dark:bg-[#151b2b]/90',
@@ -38,6 +42,83 @@ export function StudentStatCard({
 }: StudentStatCardProps) {
   const Wrapper = onClick ? 'button' : 'div'
   const dense = micro || compact
+  const tip =
+    tooltip ||
+    [label, subtitle ? String(subtitle) : null, `Current value: ${value}`]
+      .filter(Boolean)
+      .join(' — ')
+
+  const card = (
+    <Wrapper
+      type={onClick ? 'button' : undefined}
+      onClick={onClick}
+      className={cn(
+        'w-full h-full text-left rounded-xl sm:rounded-2xl border transition-all duration-200',
+        'border-gray-200/70 dark:border-white/10 shadow-sm hover:shadow-md',
+        bgClass,
+        active && 'ring-2 ring-blue-500/50 border-blue-400/60',
+        micro ? 'p-1.5 sm:p-3 rounded-lg sm:rounded-2xl' : compact ? 'p-2 sm:p-3' : 'p-3.5 sm:p-4'
+      )}
+    >
+      <div className="flex items-start justify-between gap-1 sm:gap-2">
+        <div className="min-w-0 flex-1">
+          <p
+            className={cn(
+              'font-medium text-gray-500 dark:text-gray-400 truncate',
+              micro
+                ? 'text-[9px] sm:text-xs mb-0 leading-tight'
+                : dense
+                  ? 'text-[10px] sm:text-xs mb-0.5'
+                  : 'text-xs sm:text-sm mb-1'
+            )}
+          >
+            {label}
+          </p>
+          <p
+            className={cn(
+              'font-bold text-gray-900 dark:text-white tabular-nums leading-none',
+              micro
+                ? 'text-sm sm:text-xl'
+                : dense
+                  ? 'text-base sm:text-xl'
+                  : 'text-2xl sm:text-3xl'
+            )}
+          >
+            {value}
+          </p>
+          {subtitle && (
+            <p
+              className={cn(
+                'font-medium truncate',
+                colorClass,
+                micro
+                  ? 'mt-0.5 text-[8px] sm:text-[10px] hidden sm:block'
+                  : dense
+                    ? 'mt-1 text-[10px] hidden sm:block'
+                    : 'mt-1 text-xs'
+              )}
+            >
+              {subtitle}
+            </p>
+          )}
+        </div>
+        <div
+          className={cn(
+            'rounded-lg sm:rounded-xl shrink-0 flex items-center justify-center',
+            iconBgClass,
+            micro ? 'w-6 h-6 sm:w-8 sm:h-8' : dense ? 'w-7 h-7 sm:w-8 sm:h-8' : 'w-10 h-10'
+          )}
+        >
+          <Icon
+            className={cn(
+              micro ? 'w-3 h-3 sm:w-4 sm:h-4' : dense ? 'w-3.5 h-3.5 sm:w-4 sm:h-4' : 'w-5 h-5',
+              colorClass
+            )}
+          />
+        </div>
+      </div>
+    </Wrapper>
+  )
 
   return (
     <motion.div
@@ -46,75 +127,9 @@ export function StudentStatCard({
       transition={{ duration: 0.3, delay: Math.min(index * 0.04, 0.24) }}
       className={cn('w-full h-full min-w-0', className)}
     >
-      <Wrapper
-        type={onClick ? 'button' : undefined}
-        onClick={onClick}
-        className={cn(
-          'w-full h-full text-left rounded-xl sm:rounded-2xl border transition-all duration-200',
-          'border-gray-200/70 dark:border-white/10 shadow-sm hover:shadow-md',
-          bgClass,
-          active && 'ring-2 ring-blue-500/50 border-blue-400/60',
-          micro ? 'p-1.5 sm:p-3 rounded-lg sm:rounded-2xl' : compact ? 'p-2 sm:p-3' : 'p-3.5 sm:p-4'
-        )}
-      >
-        <div className="flex items-start justify-between gap-1 sm:gap-2">
-          <div className="min-w-0 flex-1">
-            <p
-              className={cn(
-                'font-medium text-gray-500 dark:text-gray-400 truncate',
-                micro
-                  ? 'text-[9px] sm:text-xs mb-0 leading-tight'
-                  : dense
-                    ? 'text-[10px] sm:text-xs mb-0.5'
-                    : 'text-xs sm:text-sm mb-1'
-              )}
-            >
-              {label}
-            </p>
-            <p
-              className={cn(
-                'font-bold text-gray-900 dark:text-white tabular-nums leading-none',
-                micro
-                  ? 'text-sm sm:text-xl'
-                  : dense
-                    ? 'text-base sm:text-xl'
-                    : 'text-2xl sm:text-3xl'
-              )}
-            >
-              {value}
-            </p>
-            {subtitle && (
-              <p
-                className={cn(
-                  'font-medium truncate',
-                  colorClass,
-                  micro
-                    ? 'mt-0.5 text-[8px] sm:text-[10px] hidden sm:block'
-                    : dense
-                      ? 'mt-1 text-[10px] hidden sm:block'
-                      : 'mt-1 text-xs'
-                )}
-              >
-                {subtitle}
-              </p>
-            )}
-          </div>
-          <div
-            className={cn(
-              'rounded-lg sm:rounded-xl shrink-0 flex items-center justify-center',
-              iconBgClass,
-              micro ? 'w-6 h-6 sm:w-8 sm:h-8' : dense ? 'w-7 h-7 sm:w-8 sm:h-8' : 'w-10 h-10'
-            )}
-          >
-            <Icon
-              className={cn(
-                micro ? 'w-3 h-3 sm:w-4 sm:h-4' : dense ? 'w-3.5 h-3.5 sm:w-4 sm:h-4' : 'w-5 h-5',
-                colorClass
-              )}
-            />
-          </div>
-        </div>
-      </Wrapper>
+      <Tooltip content={tip}>
+        {card}
+      </Tooltip>
     </motion.div>
   )
 }

--- a/components/ui/BottomSheet.tsx
+++ b/components/ui/BottomSheet.tsx
@@ -124,7 +124,7 @@ export function BottomSheet({
                 <button
                   type="button"
                   onClick={onClose}
-                  className="inline-flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white"
+                  className="inline-flex h-11 w-11 items-center justify-center rounded-full text-gray-500 transition-colors hover:bg-gray-100 hover:text-gray-800 dark:text-gray-400 dark:hover:bg-white/10 dark:hover:text-white"
                   aria-label="Close"
                 >
                   <X className="h-5 w-5" />

--- a/components/ui/MobileBottomNav.tsx
+++ b/components/ui/MobileBottomNav.tsx
@@ -1,0 +1,160 @@
+"use client"
+
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+
+export interface MobileBottomNavItem {
+  href: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  shortLabel?: string
+  active: boolean
+  onNavigate?: () => void
+}
+
+export interface MobileBottomNavProps {
+  items: MobileBottomNavItem[]
+  /** Optional trailing action (e.g. More menu). */
+  trailing?: React.ReactNode
+  className?: string
+  /** Floating pill style (corporate) vs edge-to-edge bar. */
+  variant?: "bar" | "floating"
+  "aria-label"?: string
+}
+
+/**
+ * Shared mobile footer nav: 44px touch targets, safe-area, elevation, active state.
+ */
+export function MobileBottomNav({
+  items,
+  trailing,
+  className,
+  variant = "bar",
+  "aria-label": ariaLabel = "Mobile navigation",
+}: MobileBottomNavProps) {
+  const inner = (
+    <div
+      className={cn(
+        "flex w-full items-stretch justify-around gap-0.5 px-1",
+        variant === "floating" ? "py-1.5" : "py-1"
+      )}
+    >
+      {items.map((item) => {
+        const Icon = item.icon
+        const label = item.shortLabel ?? item.label
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            onClick={() => {
+              if (!item.active) item.onNavigate?.()
+            }}
+            aria-current={item.active ? "page" : undefined}
+            className={cn(
+              "relative flex min-h-[44px] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-0.5 transition-colors",
+              item.active
+                ? "text-blue-600 dark:text-blue-400"
+                : "text-gray-500 dark:text-gray-400"
+            )}
+          >
+            <span
+              className={cn(
+                "flex h-9 w-9 items-center justify-center rounded-xl transition-colors",
+                item.active && "bg-blue-500/15 dark:bg-blue-500/20"
+              )}
+            >
+              <Icon className="h-5 w-5 shrink-0" aria-hidden />
+            </span>
+            <span className="max-w-full truncate px-0.5 text-[10px] font-medium leading-tight">
+              {label}
+            </span>
+            {item.active ? (
+              <span
+                className="absolute bottom-0.5 h-0.5 w-4 rounded-full bg-blue-500"
+                aria-hidden
+              />
+            ) : null}
+          </Link>
+        )
+      })}
+      {trailing}
+    </div>
+  )
+
+  if (variant === "floating") {
+    return (
+      <nav
+        aria-label={ariaLabel}
+        className={cn(
+          "lg:hidden fixed z-50 left-3 right-3",
+          "bottom-[max(0.75rem,env(safe-area-inset-bottom))]",
+          className
+        )}
+        style={{ touchAction: "none" }}
+      >
+        <div
+          className={cn(
+            "rounded-2xl border border-gray-200/80 bg-white/95 shadow-[0_-4px_24px_rgba(0,0,0,0.12)] backdrop-blur-md",
+            "dark:border-white/10 dark:bg-[#0f1219]/95 dark:shadow-[0_10px_40px_rgba(0,0,0,0.55)]"
+          )}
+        >
+          {inner}
+        </div>
+      </nav>
+    )
+  }
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className={cn(
+        "lg:hidden fixed bottom-0 left-0 right-0 z-50",
+        "border-t border-gray-200/80 bg-white/95 backdrop-blur-md",
+        "shadow-[0_-4px_20px_rgba(0,0,0,0.12)]",
+        "dark:border-white/10 dark:bg-[#0f1219]/95 dark:shadow-[0_-4px_20px_rgba(0,0,0,0.35)]",
+        "pb-safe",
+        className
+      )}
+      style={{ touchAction: "none" }}
+    >
+      {inner}
+    </nav>
+  )
+}
+
+export function MobileBottomNavAction({
+  label,
+  icon: Icon,
+  onClick,
+  active,
+}: {
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+  onClick: () => void
+  active?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "relative flex min-h-[44px] min-w-0 flex-1 flex-col items-center justify-center gap-0.5 rounded-xl px-0.5 transition-colors",
+        active
+          ? "text-blue-600 dark:text-blue-400"
+          : "text-gray-500 dark:text-gray-400"
+      )}
+    >
+      <span
+        className={cn(
+          "flex h-9 w-9 items-center justify-center rounded-xl transition-colors",
+          active && "bg-blue-500/15 dark:bg-blue-500/20"
+        )}
+      >
+        <Icon className="h-5 w-5 shrink-0" aria-hidden />
+      </span>
+      <span className="max-w-full truncate px-0.5 text-[10px] font-medium leading-tight">
+        {label}
+      </span>
+    </button>
+  )
+}

--- a/components/ui/StickyFilterPanel.tsx
+++ b/components/ui/StickyFilterPanel.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { cn } from "@/lib/utils"
+
+export interface StickyFilterPanelProps {
+  children: React.ReactNode
+  /** Panel title shown in the sticky card header. */
+  title?: string
+  /** Optional clear action in the header. */
+  onClear?: () => void
+  clearLabel?: string
+  className?: string
+  /** Extra classes on the inner card. */
+  cardClassName?: string
+  /**
+   * Offset from viewport top (accounts for fixed header).
+   * Default matches app header (~5rem).
+   */
+  topClassName?: string
+  /** Max height so panel scrolls within viewport without covering footer. */
+  maxHeightClassName?: string
+}
+
+/**
+ * Desktop sticky filter shell. Hidden below `lg` — pair with MobileFilterBottomSheet.
+ * Stays visible while the content column scrolls; scrolls independently if tall.
+ */
+export function StickyFilterPanel({
+  children,
+  title = "Filters",
+  onClear,
+  clearLabel = "Clear All",
+  className,
+  cardClassName,
+  topClassName = "top-20",
+  maxHeightClassName = "max-h-[calc(100vh-5.5rem)]",
+}: StickyFilterPanelProps) {
+  return (
+    <aside
+      className={cn(
+        "sticky z-10 hidden self-start overflow-y-auto overscroll-contain lg:block",
+        topClassName,
+        maxHeightClassName,
+        className
+      )}
+    >
+      <div
+        className={cn(
+          "rounded-2xl border border-gray-200/70 bg-white p-4 shadow-sm",
+          "dark:border-white/10 dark:bg-[#151b2b]/90",
+          cardClassName
+        )}
+      >
+        {(title || onClear) && (
+          <div className="mb-4 flex items-center justify-between gap-2">
+            {title ? (
+              <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+                {title}
+              </h2>
+            ) : (
+              <span />
+            )}
+            {onClear ? (
+              <button
+                type="button"
+                onClick={onClear}
+                className="shrink-0 text-xs font-semibold text-blue-500 transition-colors hover:text-blue-400"
+              >
+                {clearLabel}
+              </button>
+            ) : null}
+          </div>
+        )}
+        {children}
+      </div>
+    </aside>
+  )
+}

--- a/components/ui/WhatsAppFloatingButton.tsx
+++ b/components/ui/WhatsAppFloatingButton.tsx
@@ -57,7 +57,7 @@ export function WhatsAppFloatingButton() {
                 // Desktop: 24px from bottom. Mobile/tablet with bottom nav: clear nav + safe-area.
                 // Bottom sheet uses z-[100], so FAB stays under sheets when open.
                 hasMobileBottomNav
-                    ? 'bottom-[calc(5.25rem+env(safe-area-inset-bottom,0px))] lg:bottom-6'
+                    ? 'bottom-[calc(5.5rem+env(safe-area-inset-bottom,0px))] lg:bottom-6'
                     : 'bottom-[calc(1.5rem+env(safe-area-inset-bottom,0px))] lg:bottom-6'
             )}
         >

--- a/components/ui/footer.tsx
+++ b/components/ui/footer.tsx
@@ -19,17 +19,17 @@ export function Footer() {
                         <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed">
                             Support available for students, universities, and recruiters across India.
                         </p>
-                        <div className="flex space-x-4 pt-2 justify-center md:justify-start">
-                            <a href="https://twitter.com/hirekarma" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-primary-500 transition-colors" aria-label="Twitter">
+                        <div className="flex space-x-2 pt-2 justify-center md:justify-start">
+                            <a href="https://twitter.com/hirekarma" target="_blank" rel="noopener noreferrer" className="inline-flex h-11 w-11 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-primary-500 dark:hover:bg-white/10" aria-label="Twitter">
                                 <Twitter className="w-5 h-5" />
                             </a>
-                            <a href="https://www.linkedin.com/company/hirekarma-pvt-ltd" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-primary-500 transition-colors" aria-label="LinkedIn">
+                            <a href="https://www.linkedin.com/company/hirekarma-pvt-ltd" target="_blank" rel="noopener noreferrer" className="inline-flex h-11 w-11 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-primary-500 dark:hover:bg-white/10" aria-label="LinkedIn">
                                 <Linkedin className="w-5 h-5" />
                             </a>
-                            <a href="https://facebook.com/hirekarma" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-primary-500 transition-colors" aria-label="Facebook">
+                            <a href="https://facebook.com/hirekarma" target="_blank" rel="noopener noreferrer" className="inline-flex h-11 w-11 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-primary-500 dark:hover:bg-white/10" aria-label="Facebook">
                                 <Facebook className="w-5 h-5" />
                             </a>
-                            <a href="https://instagram.com/hirekarma" target="_blank" rel="noopener noreferrer" className="text-gray-400 hover:text-primary-500 transition-colors" aria-label="Instagram">
+                            <a href="https://instagram.com/hirekarma" target="_blank" rel="noopener noreferrer" className="inline-flex h-11 w-11 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-primary-500 dark:hover:bg-white/10" aria-label="Instagram">
                                 <Instagram className="w-5 h-5" />
                             </a>
                         </div>

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,258 @@
+"use client"
+
+import * as React from "react"
+import { createPortal } from "react-dom"
+import { cn } from "@/lib/utils"
+
+type TooltipSide = "top" | "bottom" | "left" | "right"
+
+export interface TooltipProps {
+  content: React.ReactNode
+  children: React.ReactElement
+  side?: TooltipSide
+  /** Delay before showing on hover (ms). */
+  delayMs?: number
+  /** Disable the tooltip entirely. */
+  disabled?: boolean
+  className?: string
+  /** Prefer info-icon trigger pattern on touch devices when true. */
+  showInfoIcon?: boolean
+  /** Accessible label for the info icon button. */
+  infoLabel?: string
+}
+
+interface Coords {
+  top: number
+  left: number
+}
+
+const LONG_PRESS_MS = 450
+
+function computePosition(
+  rect: DOMRect,
+  tipWidth: number,
+  tipHeight: number,
+  side: TooltipSide
+): Coords {
+  const gap = 8
+  switch (side) {
+    case "bottom":
+      return {
+        top: rect.bottom + gap,
+        left: rect.left + rect.width / 2 - tipWidth / 2,
+      }
+    case "left":
+      return {
+        top: rect.top + rect.height / 2 - tipHeight / 2,
+        left: rect.left - tipWidth - gap,
+      }
+    case "right":
+      return {
+        top: rect.top + rect.height / 2 - tipHeight / 2,
+        left: rect.right + gap,
+      }
+    case "top":
+    default:
+      return {
+        top: rect.top - tipHeight - gap,
+        left: rect.left + rect.width / 2 - tipWidth / 2,
+      }
+  }
+}
+
+function clampToViewport(coords: Coords, tipWidth: number, tipHeight: number): Coords {
+  const pad = 8
+  const maxLeft = window.innerWidth - tipWidth - pad
+  const maxTop = window.innerHeight - tipHeight - pad
+  return {
+    left: Math.min(Math.max(pad, coords.left), Math.max(pad, maxLeft)),
+    top: Math.min(Math.max(pad, coords.top), Math.max(pad, maxTop)),
+  }
+}
+
+/**
+ * Accessible tooltip: hover on desktop, long-press on touch.
+ * Optional info icon avoids conflicting with tap targets on mobile.
+ */
+export function Tooltip({
+  content,
+  children,
+  side = "top",
+  delayMs = 280,
+  disabled = false,
+  className,
+  showInfoIcon = false,
+  infoLabel = "More info",
+}: TooltipProps) {
+  const triggerRef = React.useRef<HTMLElement | null>(null)
+  const tipRef = React.useRef<HTMLDivElement | null>(null)
+  const [open, setOpen] = React.useState(false)
+  const [coords, setCoords] = React.useState<Coords>({ top: 0, left: 0 })
+  const [mounted, setMounted] = React.useState(false)
+  const hoverTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+  const pressTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  React.useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const clearTimers = React.useCallback(() => {
+    if (hoverTimer.current) clearTimeout(hoverTimer.current)
+    if (pressTimer.current) clearTimeout(pressTimer.current)
+    hoverTimer.current = null
+    pressTimer.current = null
+  }, [])
+
+  const updatePosition = React.useCallback(() => {
+    const el = triggerRef.current
+    const tip = tipRef.current
+    if (!el || !tip) return
+    const rect = el.getBoundingClientRect()
+    const tipRect = tip.getBoundingClientRect()
+    const raw = computePosition(rect, tipRect.width, tipRect.height, side)
+    setCoords(clampToViewport(raw, tipRect.width, tipRect.height))
+  }, [side])
+
+  React.useLayoutEffect(() => {
+    if (!open) return
+    updatePosition()
+    const onScroll = () => updatePosition()
+    window.addEventListener("scroll", onScroll, true)
+    window.addEventListener("resize", onScroll)
+    return () => {
+      window.removeEventListener("scroll", onScroll, true)
+      window.removeEventListener("resize", onScroll)
+    }
+  }, [open, updatePosition, content])
+
+  React.useEffect(() => () => clearTimers(), [clearTimers])
+
+  const show = React.useCallback(() => {
+    if (disabled || !content) return
+    setOpen(true)
+  }, [disabled, content])
+
+  const hide = React.useCallback(() => {
+    clearTimers()
+    setOpen(false)
+  }, [clearTimers])
+
+  const scheduleShow = React.useCallback(() => {
+    if (disabled || !content) return
+    clearTimers()
+    hoverTimer.current = setTimeout(show, delayMs)
+  }, [clearTimers, delayMs, disabled, content, show])
+
+  const child = React.Children.only(children)
+
+  const childProps = {
+    ref: (node: HTMLElement | null) => {
+      triggerRef.current = node
+      const existingRef = (child as React.ReactElement & { ref?: React.Ref<HTMLElement> }).ref
+      if (typeof existingRef === "function") existingRef(node)
+      else if (existingRef && typeof existingRef === "object") {
+        ;(existingRef as React.MutableRefObject<HTMLElement | null>).current = node
+      }
+    },
+    onMouseEnter: (e: React.MouseEvent) => {
+      child.props.onMouseEnter?.(e)
+      scheduleShow()
+    },
+    onMouseLeave: (e: React.MouseEvent) => {
+      child.props.onMouseLeave?.(e)
+      hide()
+    },
+    onFocus: (e: React.FocusEvent) => {
+      child.props.onFocus?.(e)
+      scheduleShow()
+    },
+    onBlur: (e: React.FocusEvent) => {
+      child.props.onBlur?.(e)
+      hide()
+    },
+    onTouchStart: (e: React.TouchEvent) => {
+      child.props.onTouchStart?.(e)
+      if (showInfoIcon) return
+      clearTimers()
+      pressTimer.current = setTimeout(() => {
+        show()
+      }, LONG_PRESS_MS)
+    },
+    onTouchEnd: (e: React.TouchEvent) => {
+      child.props.onTouchEnd?.(e)
+      if (pressTimer.current) {
+        clearTimeout(pressTimer.current)
+        pressTimer.current = null
+      }
+      // Keep open briefly after long-press so user can read
+      if (open) {
+        setTimeout(hide, 1800)
+      }
+    },
+    onTouchMove: (e: React.TouchEvent) => {
+      child.props.onTouchMove?.(e)
+      if (pressTimer.current) {
+        clearTimeout(pressTimer.current)
+        pressTimer.current = null
+      }
+    },
+    "aria-describedby": open ? "hk-tooltip" : undefined,
+  }
+
+  const cloned = React.cloneElement(child, childProps)
+
+  const tipNode =
+    mounted && open && content
+      ? createPortal(
+          <div
+            ref={tipRef}
+            id="hk-tooltip"
+            role="tooltip"
+            style={{ top: coords.top, left: coords.left }}
+            className={cn(
+              "pointer-events-none fixed z-[120] max-w-[240px] rounded-lg px-2.5 py-1.5 text-xs font-medium leading-snug shadow-lg",
+              "bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900",
+              "opacity-100 transition-opacity duration-150",
+              className
+            )}
+          >
+            {content}
+          </div>,
+          document.body
+        )
+      : null
+
+  if (showInfoIcon) {
+    return (
+      <span className="inline-flex items-center gap-1">
+        {cloned}
+        <button
+          type="button"
+          aria-label={infoLabel}
+          className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-white/10 dark:hover:text-gray-200"
+          onClick={(e) => {
+            e.stopPropagation()
+            if (open) hide()
+            else {
+              triggerRef.current = e.currentTarget
+              show()
+            }
+          }}
+          onBlur={hide}
+        >
+          <span className="text-[11px] font-bold leading-none" aria-hidden>
+            i
+          </span>
+        </button>
+        {tipNode}
+      </span>
+    )
+  }
+
+  return (
+    <>
+      {cloned}
+      {tipNode}
+    </>
+  )
+}


### PR DESCRIPTION
Shared primitives
StickyFilterPanel — desktop sticky side filters (clears header/footer overlap)
MobileFilterBottomSheet + BottomSheet — reused; larger close target
MobileBottomNav — 44px touch targets, safe-area, active indicator, elevation
Tooltip — hover (desktop), long-press (mobile), theme-aware
Filters
Jobs (AllJobs): sticky sidebar via StickyFilterPanel + existing mobile sheet; shared JobsFilterFields
Events: filter sidebar sticky on desktop
Student practice/assessments: redesigned chips/sections, sticky desktop sidebar, mobile bottom sheet with draft→Apply, active chips
University students: mobile bottom sheet filters
Admin assessments: search + mobile sheet; desktop selects retained
Footer (mobile)
Student, Admin, University bottom navs use MobileBottomNav
Corporate nav: larger touch targets / labels
Body bottom padding + WhatsApp FAB clearance increased
Marketing footer social icons: 44px targets
Tooltips
Dashboard stats, student stat cards, job application status badges, practice stats